### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Uses `yt-dlp` to download YouTube content and connects it to LLMs via [Model Context Protocol](https://modelcontextprotocol.io/introduction). 
 
+<a href="https://glama.ai/mcp/servers/0nvr1xbmpk"><img width="380" height="200" src="https://glama.ai/mcp/servers/0nvr1xbmpk/badge" alt="YouTube Server MCP server" /></a>
+
 ## Features
 
 - Download YouTube subtitles (SRT format) for LLMs to read


### PR DESCRIPTION
This PR adds a badge for the [YouTube MCP Server](https://glama.ai/mcp/servers/0nvr1xbmpk) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/0nvr1xbmpk"><img width="380" height="200" src="https://glama.ai/mcp/servers/0nvr1xbmpk/badge" alt="YouTube Server MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.