### PR TITLE
Allow yt-dlp to be used for other sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # yt-dlp-mcp
 
-An MCP server implementation that integrates with yt-dlp, providing YouTube content download capabilities for LLMs.
+An MCP server implementation that integrates with yt-dlp, providing video content download capabilities (e.g. YouTube, Facebook, etc.) for LLMs.
 
 ## Features
 
-* **YouTube Subtitles**: Download subtitles in SRT format for LLMs to read
+* **Subtitles**: Download subtitles in SRT format for LLMs to read
 * **Video Download**: Save videos to your Downloads folder with resolution control
 * **Privacy-Focused**: Direct download without tracking
 * **MCP Integration**: Works with Dive and other MCP-compatible LLMs
@@ -48,21 +48,21 @@ pip install yt-dlp
 
 ## Tool Documentation
 
-* **list_youtube_subtitles**
-  * List all available subtitles for a YouTube video
+* **list_video_subtitles**
+  * List all available subtitles for a video
   * Inputs:
-    * `url` (string, required): URL of the YouTube video
+    * `url` (string, required): URL of the video
 
-* **download_youtube_srt**
-  * Download YouTube subtitles in SRT format
+* **download_video_srt**
+  * Download subtitles in SRT format
   * Inputs:
-    * `url` (string, required): URL of the YouTube video
+    * `url` (string, required): URL of the video
     * `language` (string, optional): Language code (e.g., 'en', 'zh-Hant', 'ja'). Defaults to 'en'
 
-* **download_youtube_video**
-  * Download YouTube video to user's Downloads folder
+* **download_video**
+  * Download video to user's Downloads folder
   * Inputs:
-    * `url` (string, required): URL of the YouTube video
+    * `url` (string, required): URL of the video
     * `resolution` (string, optional): Video resolution ('480p', '720p', '1080p', 'best'). Defaults to '720p'
 
 ## Usage Examples
@@ -70,6 +70,7 @@ pip install yt-dlp
 Ask your LLM to:
 ```
 "List available subtitles for this video: https://youtube.com/watch?v=..."
+"Download a video from facebook: https://facebook.com/..."
 "Download Chinese subtitles from this video: https://youtube.com/watch?v=..."
 "Download this video in 1080p: https://youtube.com/watch?v=..."
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kevinwatt/yt-dlp-mcp",
   "version": "0.6.9",
-  "description": "YouTube yt-dlp MCP Server - Download YouTube content via Model Context Protocol",
+  "description": "yt-dlp MCP Server - Download video content via Model Context Protocol",
   "keywords": [
     "mcp",
     "youtube",

--- a/src/index.mts
+++ b/src/index.mts
@@ -33,36 +33,36 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
   return {
     tools: [
       {
-        name: "list_youtube_subtitles",
-        description: "List all available subtitles for a YouTube video",
+        name: "list_video_subtitles",
+        description: "List all available subtitles for a video",
         inputSchema: {
           type: "object",
           properties: {
-            url: { type: "string", description: "URL of the YouTube video" },
+            url: { type: "string", description: "URL of the video" },
           },
           required: ["url"],
         },
       },
       {
-        name: "download_youtube_srt",
-        description: "Download YouTube subtitles in SRT format. Default language is English, falls back to available languages.",
+        name: "download_video_srt",
+        description: "Download video subtitles in SRT format. Default language is English, falls back to available languages.",
         inputSchema: {
           type: "object",
           properties: {
-            url: { type: "string", description: "URL of the YouTube video" },
+            url: { type: "string", description: "URL of the video" },
             language: { type: "string", description: "Language code (e.g., 'en', 'zh-Hant', 'ja'). Optional, defaults to 'en'" },
           },
           required: ["url"],
         },
       },
       {
-        name: "download_youtube_video",
+        name: "download_video",
         description:
-          "Download YouTube video to the user's default Downloads folder (usually ~/Downloads).",
+          "Download video to the user's default Downloads folder (usually ~/Downloads).",
         inputSchema: {
           type: "object",
           properties: {
-            url: { type: "string", description: "URL of the YouTube video" },
+            url: { type: "string", description: "URL of the video" },
             resolution: { 
               type: "string", 
               description: "Video resolution (e.g., '720p', '1080p'). Optional, defaults to '720p'",
@@ -77,12 +77,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 });
 
 /**
- * Lists all available subtitles for a YouTube video
- * @param url The URL of the YouTube video
+ * Lists all available subtitles for a video
+ * @param url The URL of the video
  * @returns Formatted list of available subtitles
  */
 async function listSubtitles(url: string): Promise<string> {
-  const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "youtube-"));
+  const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "ytdlp-"));
   
   try {
     const result = await spawnPromise(
@@ -97,13 +97,13 @@ async function listSubtitles(url: string): Promise<string> {
 }
 
 /**
- * Downloads YouTube subtitles in specified language
- * @param url The URL of the YouTube video
+ * Downloads video subtitles in specified language
+ * @param url The URL of the video
  * @param language The language code for subtitles
  * @returns Subtitle content
  */
 async function downloadSubtitles(url: string, language: string = "en"): Promise<string> {
-  const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "youtube-"));
+  const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "ytdlp-"));
 
   try {
     await spawnPromise(
@@ -135,8 +135,8 @@ async function downloadSubtitles(url: string, language: string = "en"): Promise<
 }
 
 /**
- * Downloads a YouTube video with specified resolution
- * @param url The URL of the YouTube video
+ * Downloads a video with specified resolution
+ * @param url The URL of the video
  * @param resolution The desired video resolution
  * @returns A detailed success message including the filename
  */
@@ -204,7 +204,7 @@ server.setRequestHandler(
       resolution?: string;
     };
 
-    if (toolName === "list_youtube_subtitles") {
+    if (toolName === "list_video_subtitles") {
       try {
         const subtitlesList = await listSubtitles(args.url);
         return {
@@ -216,7 +216,7 @@ server.setRequestHandler(
           isError: true,
         };
       }
-    } else if (toolName === "download_youtube_srt") {
+    } else if (toolName === "download_video_srt") {
       try {
         const subtitles = await downloadSubtitles(args.url, args.language);
         return {
@@ -228,7 +228,7 @@ server.setRequestHandler(
           isError: true,
         };
       }
-    } else if (toolName === "download_youtube_video") {
+    } else if (toolName === "download_video") {
       try {
         const message = await downloadVideo(args.url, args.resolution);
         return {


### PR DESCRIPTION
My LLM refuses to use this tool for other sites, even though yt-dlp supports it. This patch helps.