### PR TITLE
Add threaded comments output and AI-friendly markdown_tree rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Thread-aware comments processing with normalized `time_text`, `depth`, `reply_count`, and orphan lifting
+- `view` support for `ytdlp_get_video_comments` and `ytdlp_get_video_comments_summary` (`flat` or `threaded`)
+- `responseFormat="markdown_tree"` for AI-friendly comment exports with preserved reply structure
+- Full YouTube extractor comment tuple support: `maxComments`, `maxParents`, `maxReplies`, `maxRepliesPerThread`, `maxDepth`
+- Fixture-based comments test coverage for threaded output, markdown rendering, truncation, and graceful degradation
+
+### Changed
+- `ytdlp_get_video_comments` now returns `root_threads`, `reply_comments`, and `orphan_comments` in JSON responses
+- Threaded summary rendering now groups replies hierarchically instead of only showing raw parent IDs
+- README and API docs now document both comments tools and threaded comment modes
+
 ---
 
 ## [0.8.5] - 2026-05-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Threaded summary rendering now groups replies hierarchically instead of only showing raw parent IDs
 - README and API docs now document both comments tools and threaded comment modes
 
+### Fixed
+- Comments normalization now preserves numeric comment IDs and numeric parent IDs by coercing them to strings
+- `responseFormat="markdown_tree"` now rejects incompatible `view="flat"` requests instead of silently ignoring the view mode
+
 ---
 
 ## [0.8.5] - 2026-05-19

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ npm test  # Run Jest tests with ESM support
 
 ### Manual Testing
 ```bash
-npx @kevinwatt/yt-dlp-mcp  # Start MCP server manually
+node ./lib/index.mjs  # Start local built MCP server manually
 ```
 
 ## Code Architecture
@@ -32,22 +32,55 @@ npx @kevinwatt/yt-dlp-mcp  # Start MCP server manually
 This is an MCP (Model Context Protocol) server that integrates with `yt-dlp` for video/audio downloading. The server:
 
 - **Entry point**: `src/index.mts` - Main MCP server implementation with tool handlers
-- **Modular design**: Each feature lives in `src/modules/` (video.ts, audio.ts, subtitle.ts, search.ts, metadata.ts)
+- **Modular design**: Each feature lives in `src/modules/` (video.ts, audio.ts, subtitle.ts, search.ts, metadata.ts, comments.ts)
 - **Configuration**: `src/config.ts` - Centralized config with environment variable support and validation
 - **Utility functions**: `src/modules/utils.ts` - Shared spawn and cleanup utilities
 
 ### Tool Architecture
-The server exposes 10 MCP tools (all prefixed with `ytdlp_` on the wire):
+The server exposes 10 MCP tools (all prefixed with `ytdlp_` in the protocol layer):
 1. `search_videos` - YouTube video search
 2. `list_subtitle_languages` - List available subtitles
-3. `download_video_subtitles` - Download subtitle files  
+3. `download_video_subtitles` - Download subtitle files
 4. `download_video` - Download videos with resolution/trimming options
 5. `download_audio` - Extract and download audio
 6. `download_transcript` - Generate clean text transcripts
 7. `get_video_metadata` - Extract comprehensive video metadata (JSON format)
 8. `get_video_metadata_summary` - Get human-readable metadata summary
-9. `get_video_comments` - Extract comments as structured JSON (sort by top/new, up to 100)
-10. `get_video_comments_summary` - Human-readable summary of top comments (up to 50)
+9. `get_video_comments` - Extract comments as flat JSON, threaded JSON, or AI-friendly Markdown
+10. `get_video_comments_summary` - Get human-readable flat or threaded comment summaries
+
+### Comments Architecture
+The comments flow is split into small modules:
+- `src/modules/comments.ts` - yt-dlp orchestration, metadata parsing, and error mapping
+- `src/modules/comments-types.ts` - Shared comment/request/response types and extractor arg builder
+- `src/modules/comments-prepare.ts` - Normalization, deduplication, orphan lifting, and thread reconstruction
+- `src/modules/comments-render.ts` - JSON/Markdown rendering and whole-unit truncation
+- `src/modules/comments-summary.ts` - Flat/threaded summary formatting
+- `src/modules/comments-core.ts` - Re-export facade used by tests and callers
+
+Important comments behavior:
+- Preserve backward-compatible default behavior: `view="flat"` and `responseFormat="json"`
+- Normalize `time_text` from `comment.time_text ?? comment._time_text ?? null`
+- Treat missing/self-referential parents as orphans and lift them to `root`
+- For unsupported platforms without parent metadata, threaded mode degrades to root-only comments
+- Character-limit truncation must remove whole comments/threads, never cut inside an object or markdown block
+
+### Comments Tool Parameters
+`ytdlp_get_video_comments` supports:
+- `url`
+- `maxComments`
+- `sortOrder`
+- `view`: `flat | threaded`
+- `responseFormat`: `json | markdown_tree`
+- `maxParents`
+- `maxReplies`
+- `maxRepliesPerThread`
+- `maxDepth`
+
+`ytdlp_get_video_comments_summary` supports:
+- `url`
+- `maxComments`
+- `view`: `flat | threaded`
 
 ### Key Patterns
 - **Unified error handling**: `handleToolExecution()` wrapper for consistent error responses
@@ -75,6 +108,7 @@ The server exposes 10 MCP tools (all prefixed with `ytdlp_` on the wire):
 - **Jest with ESM**: Custom config for TypeScript + ESM support
 - **Test isolation**: Tests run in separate environment with mocked dependencies
 - **Coverage**: Tests for each module in `src/__tests__/`
+- **Comments tests**: `src/__tests__/comments.test.ts` is fixture-based by default; live YouTube checks remain opt-in via `RUN_INTEGRATION_TESTS=1`
 
 ### TypeScript Configuration
 - **Strict mode**: All strict TypeScript checks enabled
@@ -107,3 +141,19 @@ Comprehensive test suite in `src/__tests__/metadata.test.ts` covers:
 - Error handling for invalid URLs
 - Format validation
 - Real-world integration with YouTube videos
+
+## Comments Module Details
+
+### Key Functions
+- `getVideoComments(url, maxComments?, sortOrder?, config?, options?)`
+  - Returns flat JSON by default
+  - Supports `view="threaded"` for nested reply trees
+  - Supports `responseFormat="markdown_tree"` for AI-friendly thread exports
+- `getVideoCommentsSummary(url, maxComments?, config?, options?)`
+  - Supports `view="flat"` and `view="threaded"`
+
+### Response Notes
+- Flat JSON returns `comments: NormalizedComment[]`
+- Threaded JSON returns `comments: ThreadedComment[]`
+- Both JSON modes add `root_threads`, `reply_comments`, `orphan_comments`
+- Markdown mode is optimized for LLM consumption with `## Thread N` blocks and explicit `parent_id`, `depth`, and `reply_count`

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Get human-readable metadata summary
 Extract comments in flat JSON, threaded JSON, or AI-friendly Markdown
 - **Parameters**: `url`, `maxComments`, `sortOrder`, `view`, `responseFormat`, `maxParents`, `maxReplies`, `maxRepliesPerThread`, `maxDepth`
 - **Views**: `flat` (default) or `threaded`
-- **Formats**: `json` (default) or `markdown_tree`
+- **Formats**: `json` (default) or `markdown_tree` (`markdown_tree` requires threaded view)
 - **Returns**: Comment objects with `depth`, `reply_count`, `root_threads`, `reply_comments`, `orphan_comments`
 - **Graceful Degradation**: On platforms without parent metadata, threaded mode falls back to root-only comments
 

--- a/README.md
+++ b/README.md
@@ -342,10 +342,12 @@ Get human-readable metadata summary
 <td><code>ytdlp_get_video_comments</code></td>
 <td>
 
-Extract comments from a video in JSON format
-- **Parameters**: `url`, `maxComments` (1-100, default 20), `sortOrder` (`top` or `new`, default `top`)
-- **Returns**: Structured comments with author, likes, timestamps, pinned/uploader/verified flags, reply links
-- **Note**: Primarily supported on YouTube
+Extract comments in flat JSON, threaded JSON, or AI-friendly Markdown
+- **Parameters**: `url`, `maxComments`, `sortOrder`, `view`, `responseFormat`, `maxParents`, `maxReplies`, `maxRepliesPerThread`, `maxDepth`
+- **Views**: `flat` (default) or `threaded`
+- **Formats**: `json` (default) or `markdown_tree`
+- **Returns**: Comment objects with `depth`, `reply_count`, `root_threads`, `reply_comments`, `orphan_comments`
+- **Graceful Degradation**: On platforms without parent metadata, threaded mode falls back to root-only comments
 
 </td>
 </tr>
@@ -353,9 +355,10 @@ Extract comments from a video in JSON format
 <td><code>ytdlp_get_video_comments_summary</code></td>
 <td>
 
-Get a human-readable summary of top comments
-- **Parameters**: `url`, `maxComments` (1-50, default 10)
-- **Returns**: Formatted text with author tags ([UPLOADER]/[VERIFIED]/[PINNED]), time posted, likes, and comment text (truncated at 300 chars)
+Get a human-readable summary of comments
+- **Parameters**: `url`, `maxComments`, `view`
+- **Views**: `flat` (linear summary) or `threaded` (grouped reply trees)
+- **Returns**: Readable comment digest with author badges, time, likes, and grouped replies
 
 </td>
 </tr>
@@ -381,6 +384,16 @@ Get a human-readable summary of top comments
 "Show me the title, channel, and view count for this video"
 "Extract just the duration and upload date"
 "Give me a quick summary of this video's info"
+```
+
+### Get Comments
+
+```
+"Get the top 20 comments for https://youtube.com/watch?v=..."
+"Get comments as threaded JSON for this video"
+"Extract comments as markdown_tree so the reply branches stay intact"
+"Get newest comments with maxDepth 1 and maxRepliesPerThread 0"
+"Summarize comments in threaded view"
 ```
 
 ### Download Subtitles & Transcripts
@@ -517,6 +530,45 @@ Found 50 videos (showing 10):
    ⏱️  Duration: 10:30
    🔗 URL: https://...
 ```
+
+### Comment Markdown Tree
+Useful for LLM analysis when reply context matters:
+```markdown
+# AI-Ready Comment Threads
+
+source_title: "Sample Video"
+comments_detected: 20
+root_threads: 6
+reply_comments: 14
+
+## Threads
+
+### Thread 1
+
+- comment_id: "abc123"
+  parent_id: "root"
+  depth: 0
+  reply_count: 2
+  text:
+    | Root comment text
+  - comment_id: "reply456"
+    parent_id: "abc123"
+    depth: 1
+    reply_count: 0
+    text:
+      | Reply text
+```
+
+### Comment Limits
+YouTube comment extraction supports the full extractor tuple:
+```text
+youtube:comment_sort=<sort>;max_comments=<total>,<parents>,<replies>,<repliesPerThread>,<depth>
+```
+
+Examples:
+- Default behavior: `maxComments=20` yields `max_comments=20,20,20,20,2`
+- Root-only comments: `maxDepth=1`, `maxRepliesPerThread=0`
+- Limited branching: `maxReplies=40`, `maxRepliesPerThread=5`, `maxDepth=2`
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -175,7 +175,7 @@ Extract comments without downloading video content. Supports flat JSON, threaded
 - `sortOrder`: (Optional) `"top"` or `"new"` (default: `"top"`)
 - `config`: (Optional) Configuration object
 - `options.view`: (Optional) `"flat"` or `"threaded"` (default: `"flat"`)
-- `options.responseFormat`: (Optional) `"json"` or `"markdown_tree"` (default: `"json"`)
+- `options.responseFormat`: (Optional) `"json"` or `"markdown_tree"` (default: `"json"`). `markdown_tree` requires `options.view="threaded"` or omitted view
 - `options.maxParents`: (Optional) Cap root comments at extractor level
 - `options.maxReplies`: (Optional) Cap total replies at extractor level
 - `options.maxRepliesPerThread`: (Optional) Cap replies per thread at extractor level

--- a/docs/api.md
+++ b/docs/api.md
@@ -163,6 +163,89 @@ const summary = await getVideoMetadataSummary('https://www.youtube.com/watch?v=j
 console.log(summary);
 ```
 
+## Comments Operations
+
+### getVideoComments(url: string, maxComments?: number, sortOrder?: "top" | "new", config?: Config, options?: GetVideoCommentsOptions): Promise<string>
+
+Extract comments without downloading video content. Supports flat JSON, threaded JSON, and AI-friendly Markdown output.
+
+**Parameters:**
+- `url`: The URL of the video to inspect
+- `maxComments`: (Optional) Maximum total comments to request (default: `20`)
+- `sortOrder`: (Optional) `"top"` or `"new"` (default: `"top"`)
+- `config`: (Optional) Configuration object
+- `options.view`: (Optional) `"flat"` or `"threaded"` (default: `"flat"`)
+- `options.responseFormat`: (Optional) `"json"` or `"markdown_tree"` (default: `"json"`)
+- `options.maxParents`: (Optional) Cap root comments at extractor level
+- `options.maxReplies`: (Optional) Cap total replies at extractor level
+- `options.maxRepliesPerThread`: (Optional) Cap replies per thread at extractor level
+- `options.maxDepth`: (Optional) Cap reply depth at extractor level (default: `2`)
+
+**Returns:**
+- Promise resolving to:
+  - Flat JSON: `{ count, has_more, root_threads, reply_comments, orphan_comments, comments: NormalizedComment[] }`
+  - Threaded JSON: `{ count, has_more, root_threads, reply_comments, orphan_comments, comments: ThreadedComment[] }`
+  - Markdown tree: AI-friendly `## Thread N` blocks with `parent_id`, `depth`, `reply_count`, and text blocks
+
+**Notes:**
+- `time_text` is normalized from either `time_text` or `_time_text`
+- Replies whose parent is missing are lifted to root and counted in `orphan_comments`
+- Platforms without reply metadata gracefully degrade to root-only comments in threaded mode
+
+**Example:**
+```javascript
+import { getVideoComments } from '@kevinwatt/yt-dlp-mcp';
+
+const flatJson = await getVideoComments(
+  'https://www.youtube.com/watch?v=jNQXAC9IVRw'
+);
+console.log(flatJson);
+
+const threadedJson = await getVideoComments(
+  'https://www.youtube.com/watch?v=jNQXAC9IVRw',
+  25,
+  'top',
+  undefined,
+  { view: 'threaded', maxRepliesPerThread: 5, maxDepth: 2 }
+);
+console.log(threadedJson);
+
+const markdownTree = await getVideoComments(
+  'https://www.youtube.com/watch?v=jNQXAC9IVRw',
+  25,
+  'new',
+  undefined,
+  { responseFormat: 'markdown_tree', maxDepth: 2 }
+);
+console.log(markdownTree);
+```
+
+### getVideoCommentsSummary(url: string, maxComments?: number, config?: Config, options?: GetVideoCommentsSummaryOptions): Promise<string>
+
+Get a readable summary of comments. Can render either a flat sequence or grouped reply threads.
+
+**Parameters:**
+- `url`: The URL of the video to inspect
+- `maxComments`: (Optional) Maximum number of comments to summarize (default: `10`)
+- `config`: (Optional) Configuration object
+- `options.view`: (Optional) `"flat"` or `"threaded"` (default: `"flat"`)
+
+**Returns:**
+- Promise resolving to a readable summary string
+
+**Example:**
+```javascript
+import { getVideoCommentsSummary } from '@kevinwatt/yt-dlp-mcp';
+
+const summary = await getVideoCommentsSummary(
+  'https://www.youtube.com/watch?v=jNQXAC9IVRw',
+  10,
+  undefined,
+  { view: 'threaded' }
+);
+console.log(summary);
+```
+
 ## Configuration
 
 ### Config Interface
@@ -191,4 +274,4 @@ interface Config {
 }
 ```
 
-For detailed configuration options, see [Configuration Guide](./configuration.md). 
+For detailed configuration options, see [Configuration Guide](./configuration.md).

--- a/src/__tests__/comments.test.ts
+++ b/src/__tests__/comments.test.ts
@@ -1,180 +1,205 @@
-// @ts-nocheck
 // @jest-environment node
-import { describe, test, expect, beforeAll } from '@jest/globals';
-import { getVideoComments, getVideoCommentsSummary } from '../modules/comments.js';
-import type { CommentsResponse } from '../modules/comments.js';
-import { CONFIG } from '../config.js';
+import { describe, test, expect } from "@jest/globals";
+import { readFileSync } from "fs";
+import {
+  buildCommentExtractorArgs,
+  formatCommentsOutput,
+  formatCommentsSummary,
+  prepareComments,
+  resolveCommentRequestOptions,
+} from "../modules/comments-core.js";
+import { getVideoComments, getVideoCommentsSummary } from "../modules/comments.js";
+import type {
+  FlatCommentsResponse,
+  ThreadedCommentsResponse,
+} from "../modules/comments.js";
+import { CONFIG } from "../config.js";
 
-// Clear Python environment to avoid yt-dlp issues
 delete process.env.PYTHONPATH;
 delete process.env.PYTHONHOME;
 
-// Integration tests require network access - opt-in via RUN_INTEGRATION_TESTS=1
-const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === '1';
+const RUN_INTEGRATION = process.env.RUN_INTEGRATION_TESTS === "1";
+const sourceInfo = {
+  sourceId: "vid-123",
+  title: "Sample Video",
+  sourceUrl: "https://example.com/video",
+  extractor: "YouTube",
+  generatedAtUtc: "2026-03-11T00:00:00.000Z",
+};
 
-(RUN_INTEGRATION ? describe : describe.skip)('Video Comments Extraction', () => {
-  // Using a popular video that should have comments enabled
-  const testUrl = 'https://www.youtube.com/watch?v=jNQXAC9IVRw';
+function loadFixture<T>(filename: string): T {
+  const url = new URL(`./fixtures/comments/${filename}`, import.meta.url);
+  return JSON.parse(readFileSync(url, "utf-8")) as T;
+}
 
-  describe('getVideoComments', () => {
-    test('should extract comments from YouTube video', async () => {
-      const commentsJson = await getVideoComments(testUrl, 5, 'top', CONFIG);
-      const data: CommentsResponse = JSON.parse(commentsJson);
+function loadTextFixture(filename: string): string {
+  const url = new URL(`./fixtures/comments/${filename}`, import.meta.url);
+  return readFileSync(url, "utf-8");
+}
 
-      // Verify response structure
-      expect(data).toHaveProperty('count');
-      expect(data).toHaveProperty('has_more');
-      expect(data).toHaveProperty('comments');
-      expect(Array.isArray(data.comments)).toBe(true);
-      expect(data.count).toBeGreaterThan(0);
-      expect(data.count).toBeLessThanOrEqual(5);
-    }, 60000);
+describe("comments-core", () => {
+  const threadedFixture = loadFixture<unknown[]>("youtube-threaded.json");
+  const nonThreadedFixture = loadFixture<unknown[]>("non-threaded.json");
 
-    test('should return comments with expected fields', async () => {
-      const commentsJson = await getVideoComments(testUrl, 3, 'top', CONFIG);
-      const data: CommentsResponse = JSON.parse(commentsJson);
+  test("builds full extractor args with reply and depth controls", () => {
+    const args = buildCommentExtractorArgs(resolveCommentRequestOptions({
+      maxComments: 20,
+      sortOrder: "new",
+      maxParents: 10,
+      maxReplies: 8,
+      maxRepliesPerThread: 3,
+      maxDepth: 4,
+    }));
 
-      if (data.comments.length > 0) {
-        const comment = data.comments[0];
+    expect(args).toBe("youtube:comment_sort=new;max_comments=20,10,8,3,4");
+  });
 
-        // These fields should typically be present
-        expect(comment).toHaveProperty('text');
-        expect(comment).toHaveProperty('author');
+  test("normalizes replies, drops duplicates, and restores time_text", () => {
+    const prepared = prepareComments(threadedFixture);
 
-        // Verify text is a string
-        if (comment.text !== undefined) {
-          expect(typeof comment.text).toBe('string');
-        }
-        if (comment.author !== undefined) {
-          expect(typeof comment.author).toBe('string');
-        }
-      }
-    }, 60000);
+    expect(prepared.detectedCount).toBe(7);
+    expect(prepared.orphanCommentIds).toEqual(["orphan-1", "self-1"]);
+    expect(prepared.hasThreading).toBe(true);
 
-    test('should respect maxComments parameter', async () => {
-      const commentsJson = await getVideoComments(testUrl, 3, 'top', CONFIG);
-      const data: CommentsResponse = JSON.parse(commentsJson);
+    const rootComment = prepared.flatComments.find((comment) => comment.id === "c1");
+    const replyComment = prepared.flatComments.find((comment) => comment.id === "r1");
+    const nestedReply = prepared.flatComments.find((comment) => comment.id === "r2");
+    const orphanReply = prepared.flatComments.find((comment) => comment.id === "orphan-1");
 
-      expect(data.comments.length).toBeLessThanOrEqual(3);
-    }, 60000);
+    expect(rootComment).toMatchObject({ parent: "root", depth: 0, reply_count: 1 });
+    expect(replyComment).toMatchObject({ parent: "c1", depth: 1, reply_count: 1, time_text: "1 day ago" });
+    expect(nestedReply).toMatchObject({ parent: "r1", depth: 2, reply_count: 0 });
+    expect(orphanReply).toMatchObject({ parent: "root", depth: 0, reply_count: 0 });
+  });
 
-    test('should support different sort orders', async () => {
-      // Just verify both sort orders work without error
-      const topComments = await getVideoComments(testUrl, 2, 'top', CONFIG);
-      const topData: CommentsResponse = JSON.parse(topComments);
-      expect(topData).toHaveProperty('comments');
+  test("returns backward-compatible flat json with reply metadata", () => {
+    const json = formatCommentsOutput(
+      threadedFixture,
+      sourceInfo,
+      resolveCommentRequestOptions({ maxComments: 20 })
+    );
+    const data = JSON.parse(json) as FlatCommentsResponse;
 
-      const newComments = await getVideoComments(testUrl, 2, 'new', CONFIG);
-      const newData: CommentsResponse = JSON.parse(newComments);
-      expect(newData).toHaveProperty('comments');
-    }, 90000);
+    expect(data.count).toBe(7);
+    expect(data.root_threads).toBe(4);
+    expect(data.reply_comments).toBe(3);
+    expect(data.orphan_comments).toBe(2);
+    expect(data.has_more).toBe(false);
+    expect(data.comments[1]).toMatchObject({
+      id: "r1",
+      parent: "c1",
+      depth: 1,
+      reply_count: 1,
+      time_text: "1 day ago",
+    });
+  });
 
-    test('should throw error for invalid URL', async () => {
-      await expect(getVideoComments('invalid-url', 5, 'top', CONFIG)).rejects.toThrow();
+  test("returns threaded json with nested replies", () => {
+    const json = formatCommentsOutput(
+      threadedFixture,
+      sourceInfo,
+      resolveCommentRequestOptions({ maxComments: 20, view: "threaded" })
+    );
+    const data = JSON.parse(json) as ThreadedCommentsResponse;
+
+    expect(data.count).toBe(7);
+    expect(data.root_threads).toBe(4);
+    expect(data.comments[0].id).toBe("c1");
+    expect(data.comments[0].replies[0].id).toBe("r1");
+    expect(data.comments[0].replies[0].replies[0].id).toBe("r2");
+    expect(data.comments[3].replies[0].id).toBe("r3");
+  });
+
+  test("renders stable markdown_tree output with thread blocks", () => {
+    const markdown = formatCommentsOutput(
+      threadedFixture,
+      sourceInfo,
+      resolveCommentRequestOptions({
+        maxComments: 20,
+        view: "threaded",
+        responseFormat: "markdown_tree",
+      })
+    );
+
+    expect(markdown).toBe(loadTextFixture("threaded-markdown.md"));
+  });
+
+  test("truncates threaded json by whole root threads", () => {
+    const fullJson = formatCommentsOutput(
+      threadedFixture,
+      sourceInfo,
+      resolveCommentRequestOptions({ maxComments: 20, view: "threaded" })
+    );
+    const truncatedJson = formatCommentsOutput(
+      threadedFixture,
+      sourceInfo,
+      resolveCommentRequestOptions({ maxComments: 20, view: "threaded" }),
+      fullJson.length - 1
+    );
+
+    const fullData = JSON.parse(fullJson) as ThreadedCommentsResponse;
+    const truncatedData = JSON.parse(truncatedJson) as ThreadedCommentsResponse;
+
+    expect(truncatedData._truncated).toBe(true);
+    expect(truncatedData.has_more).toBe(true);
+    expect(truncatedData.root_threads).toBeLessThan(fullData.root_threads);
+    expect(truncatedData.comments[truncatedData.comments.length - 1]?.parent).toBe("root");
+  });
+
+  test("gracefully degrades to root-only threads when parent metadata is missing", () => {
+    const prepared = prepareComments(nonThreadedFixture);
+    const json = formatCommentsOutput(
+      nonThreadedFixture,
+      sourceInfo,
+      resolveCommentRequestOptions({ maxComments: 10, view: "threaded" })
+    );
+    const data = JSON.parse(json) as ThreadedCommentsResponse;
+
+    expect(prepared.hasThreading).toBe(false);
+    expect(data.root_threads).toBe(3);
+    expect(data.reply_comments).toBe(0);
+    expect(data.comments.every((comment) => comment.replies.length === 0)).toBe(true);
+  });
+
+  test("renders threaded summary with grouped replies", () => {
+    const summary = formatCommentsSummary(threadedFixture, {
+      maxComments: 20,
+      view: "threaded",
     });
 
-    test('should throw error for unsupported URL', async () => {
-      await expect(getVideoComments('https://example.com/video', 5, 'top', CONFIG)).rejects.toThrow();
-    }, 30000);
+    expect(summary).toContain("Thread 1");
+    expect(summary).toContain("Reply: Bob (1 day ago)");
+    expect(summary).not.toContain("Reply to comment");
   });
+});
 
-  describe('getVideoCommentsSummary', () => {
-    test('should generate human-readable summary', async () => {
-      const summary = await getVideoCommentsSummary(testUrl, 5, CONFIG);
+(RUN_INTEGRATION ? describe : describe.skip)("comments integration", () => {
+  const testUrl = "https://www.youtube.com/watch?v=jNQXAC9IVRw";
 
-      expect(typeof summary).toBe('string');
-      expect(summary.length).toBeGreaterThan(0);
+  test("extracts threaded comments from YouTube", async () => {
+    const commentsJson = await getVideoComments(testUrl, 5, "top", CONFIG, {
+      view: "threaded",
+      maxDepth: 2,
+    });
+    const data = JSON.parse(commentsJson) as ThreadedCommentsResponse;
 
-      // Should contain header
-      expect(summary).toContain('Video Comments');
+    expect(data).toHaveProperty("count");
+    expect(data).toHaveProperty("root_threads");
+    expect(data).toHaveProperty("reply_comments");
+    expect(Array.isArray(data.comments)).toBe(true);
+  }, 90000);
 
-      // Should have formatted content
-      expect(summary).toContain('Author:');
-    }, 60000);
-
-    test('should respect maxComments parameter', async () => {
-      const summary = await getVideoCommentsSummary(testUrl, 3, CONFIG);
-
-      // Count occurrences of "Author:" to verify number of comments
-      const authorMatches = summary.match(/Author:/g) ?? [];
-      expect(authorMatches.length).toBeLessThanOrEqual(3);
-    }, 60000);
-
-    test('should throw error for invalid URL', async () => {
-      await expect(getVideoCommentsSummary('invalid-url', 5, CONFIG)).rejects.toThrow();
+  test("generates threaded comments summary", async () => {
+    const summary = await getVideoCommentsSummary(testUrl, 5, CONFIG, {
+      view: "threaded",
     });
 
-    test('should handle videos with different comment counts', async () => {
-      const summary = await getVideoCommentsSummary(testUrl, 10, CONFIG);
+    expect(typeof summary).toBe("string");
+    expect(summary).toContain("Video Comments");
+  }, 90000);
 
-      // Summary should be a valid string
-      expect(typeof summary).toBe('string');
-      expect(summary.trim().length).toBeGreaterThan(0);
-    }, 60000);
-  });
-
-  describe('Error Handling', () => {
-    test('should provide helpful error message for unavailable video', async () => {
-      const unavailableUrl = 'https://www.youtube.com/watch?v=invalid_video_id_xyz123';
-
-      await expect(getVideoComments(unavailableUrl, 5, 'top', CONFIG)).rejects.toThrow();
-    }, 30000);
-
-    test('should handle unsupported URLs gracefully', async () => {
-      const unsupportedUrl = 'https://example.com/not-a-video';
-
-      await expect(getVideoComments(unsupportedUrl, 5, 'top', CONFIG)).rejects.toThrow();
-    }, 30000);
-  });
-
-  describe('Comment Fields', () => {
-    test('should include author information when available', async () => {
-      const commentsJson = await getVideoComments(testUrl, 5, 'top', CONFIG);
-      const data: CommentsResponse = JSON.parse(commentsJson);
-
-      if (data.comments.length > 0) {
-        const comment = data.comments[0];
-
-        // Author fields
-        if (comment.author !== undefined) {
-          expect(typeof comment.author).toBe('string');
-        }
-        if (comment.author_id !== undefined) {
-          expect(typeof comment.author_id).toBe('string');
-        }
-      }
-    }, 60000);
-
-    test('should include engagement metrics when available', async () => {
-      const commentsJson = await getVideoComments(testUrl, 5, 'top', CONFIG);
-      const data: CommentsResponse = JSON.parse(commentsJson);
-
-      if (data.comments.length > 0) {
-        // At least one top comment should have like_count
-        const hasLikes = data.comments.some(c =>
-          c.like_count !== undefined && typeof c.like_count === 'number'
-        );
-        // This is optional - some comments may not have likes
-        expect(hasLikes || data.comments.length > 0).toBe(true);
-      }
-    }, 60000);
-
-    test('should handle boolean flags correctly', async () => {
-      const commentsJson = await getVideoComments(testUrl, 10, 'top', CONFIG);
-      const data: CommentsResponse = JSON.parse(commentsJson);
-
-      for (const comment of data.comments) {
-        // Boolean flags should be boolean or undefined
-        if (comment.is_pinned !== undefined) {
-          expect(typeof comment.is_pinned).toBe('boolean');
-        }
-        if (comment.author_is_uploader !== undefined) {
-          expect(typeof comment.author_is_uploader).toBe('boolean');
-        }
-        if (comment.author_is_verified !== undefined) {
-          expect(typeof comment.author_is_verified).toBe('boolean');
-        }
-      }
-    }, 60000);
+  test("throws for invalid URLs", async () => {
+    await expect(getVideoComments("invalid-url", 5, "top", CONFIG)).rejects.toThrow();
+    await expect(getVideoCommentsSummary("invalid-url", 5, CONFIG)).rejects.toThrow();
   });
 });

--- a/src/__tests__/comments.test.ts
+++ b/src/__tests__/comments.test.ts
@@ -161,6 +161,18 @@ describe("comments-core", () => {
     expect(data.comments.every((comment) => comment.replies.length === 0)).toBe(true);
   });
 
+  test("normalizes numeric ids and parent ids instead of dropping them", () => {
+    const prepared = prepareComments([
+      { id: 1, text: "Root" },
+      { id: 2, parent: 1, text: "Reply" },
+    ]);
+
+    expect(prepared.flatComments).toHaveLength(2);
+    expect(prepared.flatComments[0]).toMatchObject({ id: "1", parent: "root" });
+    expect(prepared.flatComments[1]).toMatchObject({ id: "2", parent: "1", depth: 1 });
+    expect(prepared.threadedComments[0].replies[0].id).toBe("2");
+  });
+
   test("renders threaded summary with grouped replies", () => {
     const summary = formatCommentsSummary(threadedFixture, {
       maxComments: 20,
@@ -170,6 +182,15 @@ describe("comments-core", () => {
     expect(summary).toContain("Thread 1");
     expect(summary).toContain("Reply: Bob (1 day ago)");
     expect(summary).not.toContain("Reply to comment");
+  });
+});
+
+describe("comments validation", () => {
+  test("rejects flat markdown_tree requests", async () => {
+    await expect(getVideoComments("https://www.youtube.com/watch?v=jNQXAC9IVRw", 5, "top", CONFIG, {
+      view: "flat",
+      responseFormat: "markdown_tree",
+    })).rejects.toThrow(/markdown_tree.*threaded/i);
   });
 });
 

--- a/src/__tests__/fixtures/comments/non-threaded.json
+++ b/src/__tests__/fixtures/comments/non-threaded.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "n1",
+    "text": "First flat comment",
+    "author": "Alpha",
+    "time_text": "today"
+  },
+  {
+    "id": "n2",
+    "text": "Second flat comment",
+    "author": "Beta"
+  },
+  {
+    "id": "n3",
+    "text": "Third flat comment",
+    "author": "Gamma"
+  }
+]

--- a/src/__tests__/fixtures/comments/threaded-markdown.md
+++ b/src/__tests__/fixtures/comments/threaded-markdown.md
@@ -1,0 +1,93 @@
+# AI-Ready Comment Threads
+
+source_title: "Sample Video"
+source_id: "vid-123"
+source_url: "https://example.com/video"
+extractor: "YouTube"
+generated_at_utc: "2026-03-11T00:00:00.000Z"
+raw_info_json: null
+comments_detected: 7
+comments_returned: 7
+root_threads: 4
+reply_comments: 3
+orphan_comments: 2
+has_threading: true
+has_more: false
+
+## Notes
+
+- Optimized for LLMs with stable keys, explicit `parent_id`, and preserved thread structure.
+- If the extractor does not expose `parent`, every comment is treated as a root thread.
+- `orphan_comments` means a reply arrived without its parent in the fetched payload.
+
+## Threads
+
+### Thread 1
+
+- comment_id: "c1"
+  parent_id: "root"
+  depth: 0
+  author: "Alice"
+  is_pinned: true
+  like_count: 12
+  time_text: "2 days ago"
+  reply_count: 1
+  text:
+    | Root comment 1
+  - comment_id: "r1"
+    parent_id: "c1"
+    depth: 1
+    author: "Bob"
+    time_text: "1 day ago"
+    reply_count: 1
+    text:
+      | Reply 1
+    - comment_id: "r2"
+      parent_id: "r1"
+      depth: 2
+      author: "Carol"
+      time_text: "12 hours ago"
+      reply_count: 0
+      text:
+        | Nested reply
+
+### Thread 2
+
+- comment_id: "orphan-1"
+  parent_id: "root"
+  depth: 0
+  author: "Dana"
+  time_text: "3 hours ago"
+  reply_count: 0
+  text:
+    | Orphan reply
+
+### Thread 3
+
+- comment_id: "self-1"
+  parent_id: "root"
+  depth: 0
+  author: "Eve"
+  time_text: "1 hour ago"
+  reply_count: 0
+  text:
+    | Self parent
+
+### Thread 4
+
+- comment_id: "c2"
+  parent_id: "root"
+  depth: 0
+  author: "Frank"
+  like_count: 1
+  time_text: "4 days ago"
+  reply_count: 1
+  text:
+    | Root comment 2
+  - comment_id: "r3"
+    parent_id: "c2"
+    depth: 1
+    author: "Grace"
+    reply_count: 0
+    text:
+      | Reply to second root

--- a/src/__tests__/fixtures/comments/youtube-threaded.json
+++ b/src/__tests__/fixtures/comments/youtube-threaded.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "c1",
+    "text": "Root comment 1",
+    "author": "Alice",
+    "like_count": 12,
+    "time_text": "2 days ago",
+    "is_pinned": true
+  },
+  {
+    "id": "r1",
+    "text": "Reply 1",
+    "author": "Bob",
+    "parent": "c1",
+    "_time_text": "1 day ago"
+  },
+  {
+    "id": "r2",
+    "text": "Nested reply",
+    "author": "Carol",
+    "parent": "r1",
+    "time_text": "12 hours ago"
+  },
+  {
+    "id": "c1",
+    "text": "Duplicate ignored",
+    "author": "Duplicate"
+  },
+  {
+    "id": "orphan-1",
+    "text": "Orphan reply",
+    "author": "Dana",
+    "parent": "missing-parent",
+    "time_text": "3 hours ago"
+  },
+  {
+    "id": "self-1",
+    "text": "Self parent",
+    "author": "Eve",
+    "parent": "self-1",
+    "time_text": "1 hour ago"
+  },
+  {
+    "id": "c2",
+    "text": "Root comment 2",
+    "author": "Frank",
+    "like_count": 1,
+    "time_text": "4 days ago"
+  },
+  {
+    "id": "r3",
+    "text": "Reply to second root",
+    "author": "Grace",
+    "parent": "c2"
+  }
+]

--- a/src/index.mts
+++ b/src/index.mts
@@ -137,6 +137,36 @@ const GetVideoCommentsInput = {
   sortOrder: z.enum(["top", "new"])
     .default("top")
     .describe("Sort order: 'top' for most liked, 'new' for newest (default: 'top')"),
+  view: z.enum(["flat", "threaded"])
+    .default("flat")
+    .describe("Comment view: 'flat' for backward-compatible list output, 'threaded' for reply trees"),
+  responseFormat: z.enum(["json", "markdown_tree"])
+    .default("json")
+    .describe("Response format: 'json' for structured data, 'markdown_tree' for AI-friendly threaded Markdown (requires threaded view)"),
+  maxParents: z.coerce.number()
+    .int("Must be a whole number")
+    .min(0, "Cannot be negative")
+    .max(100, "Cannot exceed 100 parent comments")
+    .optional()
+    .describe("Optional cap for root comments passed to yt-dlp's YouTube extractor"),
+  maxReplies: z.coerce.number()
+    .int("Must be a whole number")
+    .min(0, "Cannot be negative")
+    .max(100, "Cannot exceed 100 reply comments")
+    .optional()
+    .describe("Optional cap for total replies passed to yt-dlp's YouTube extractor"),
+  maxRepliesPerThread: z.coerce.number()
+    .int("Must be a whole number")
+    .min(0, "Cannot be negative")
+    .max(100, "Cannot exceed 100 replies per thread")
+    .optional()
+    .describe("Optional cap for replies per thread passed to yt-dlp's YouTube extractor"),
+  maxDepth: z.coerce.number()
+    .int("Must be a whole number")
+    .min(1, "Depth must be at least 1")
+    .max(10, "Depth cannot exceed 10")
+    .optional()
+    .describe("Optional maximum reply depth passed to yt-dlp's YouTube extractor (default: 2)"),
 };
 
 const GetVideoCommentsSummaryInput = {
@@ -149,6 +179,9 @@ const GetVideoCommentsSummaryInput = {
     .max(50, "Cannot exceed 50 comments for summary")
     .default(10)
     .describe("Maximum number of comments to include in summary (1-50, default: 10)"),
+  view: z.enum(["flat", "threaded"])
+    .default("flat")
+    .describe("Summary view: 'flat' for linear comments, 'threaded' for grouped reply trees"),
 };
 
 /**
@@ -568,19 +601,28 @@ Error Handling:
 server.registerTool(
   "ytdlp_get_video_comments",
   {
-    description: `Extract comments from a video in JSON format.
+    description: `Extract comments from a video in JSON or AI-friendly Markdown format.
 
-This tool retrieves comments from videos (primarily YouTube) using yt-dlp's comment extraction feature. Returns structured comment data including author info, likes, and timestamps.
+This tool retrieves comments from videos (primarily YouTube) using yt-dlp's comment extraction feature. It supports backward-compatible flat JSON, threaded JSON with nested replies, and AI-friendly Markdown that preserves thread structure.
 
 Args:
   - url (string): Full video URL
   - maxComments (number): Maximum comments to retrieve (1-100, default: 20)
   - sortOrder (enum): 'top' for most liked comments, 'new' for newest (default: 'top')
+  - view (enum): 'flat' for linear output, 'threaded' for nested replies (default: 'flat')
+  - responseFormat (enum): 'json' for structured data, 'markdown_tree' for AI-friendly threaded Markdown (default: 'json', requires threaded view)
+  - maxParents (number, optional): Cap root comments at extractor level
+  - maxReplies (number, optional): Cap total replies at extractor level
+  - maxRepliesPerThread (number, optional): Cap replies per thread at extractor level
+  - maxDepth (number, optional): Cap reply depth at extractor level (default: 2)
 
 Returns:
-  JSON object with:
+  JSON format:
   - count: Number of comments returned
   - has_more: Whether more comments are available
+  - root_threads: Number of root comments returned
+  - reply_comments: Number of reply comments returned
+  - orphan_comments: Replies whose parent was missing and had to be lifted to root
   - comments: Array of comment objects containing:
     - id: Comment identifier
     - text: Comment content
@@ -593,11 +635,16 @@ Returns:
     - parent: Parent comment ID (for replies)
     - timestamp: Unix timestamp
     - time_text: Human-readable time (e.g., "2 days ago")
+    - depth: Reply depth in the reconstructed tree
+    - reply_count: Number of direct replies included
+
+  Threaded JSON additionally nests replies inside each root comment under 'replies: []'.
+  Markdown format returns '## Thread N' blocks with explicit 'parent_id', 'depth', 'reply_count', and pipe-prefixed text blocks.
 
 Use when: You need structured comment data for analysis or display
 Don't use when: You want a quick readable overview (use ytdlp_get_video_comments_summary)
 
-Note: Comment extraction is primarily supported for YouTube. Other platforms may have limited support.
+Note: Comment extraction is primarily supported for YouTube. On platforms without reply metadata, threaded mode degrades gracefully to root-only comments.
 
 Error Handling:
   - "Video is unavailable or private" for inaccessible content
@@ -612,9 +659,16 @@ Error Handling:
       openWorldHint: true
     }
   },
-  async ({ url, maxComments, sortOrder }) =>
+  async ({ url, maxComments, sortOrder, view, responseFormat, maxParents, maxReplies, maxRepliesPerThread, maxDepth }) =>
     handleToolExecution(
-      () => getVideoComments(url, maxComments, sortOrder, CONFIG),
+      () => getVideoComments(url, maxComments, sortOrder, CONFIG, {
+        view,
+        responseFormat,
+        maxParents,
+        maxReplies,
+        maxRepliesPerThread,
+        maxDepth,
+      }),
       "Error extracting video comments"
     )
 );
@@ -624,11 +678,12 @@ server.registerTool(
   {
     description: `Get a human-readable summary of video comments.
 
-This tool extracts comments and formats them into an easy-to-read summary. Perfect for quick overview of audience reactions and popular comments.
+This tool extracts comments and formats them into an easy-to-read summary. It can render either a linear flat list or grouped reply threads.
 
 Args:
   - url (string): Full video URL
   - maxComments (number): Maximum comments to include (1-50, default: 10)
+  - view (enum): 'flat' for linear comments, 'threaded' for grouped reply trees (default: 'flat')
 
 Returns:
   Formatted text summary with:
@@ -636,7 +691,7 @@ Returns:
   - Time posted (e.g., "2 days ago")
   - Like count
   - Comment text (truncated to 300 chars if longer)
-  - Reply indicators
+  - Reply grouping in threaded mode
 
 Use when: You want a quick, readable overview of video comments
 Don't use when: You need complete structured data (use ytdlp_get_video_comments)
@@ -653,9 +708,9 @@ Error Handling:
       openWorldHint: true
     }
   },
-  async ({ url, maxComments }) =>
+  async ({ url, maxComments, view }) =>
     handleToolExecution(
-      () => getVideoCommentsSummary(url, maxComments, CONFIG),
+      () => getVideoCommentsSummary(url, maxComments, CONFIG, { view }),
       "Error generating video comments summary"
     )
 );

--- a/src/modules/comments-core.ts
+++ b/src/modules/comments-core.ts
@@ -1,0 +1,3 @@
+export * from "./comments-types.js";
+export { prepareComments } from "./comments-prepare.js";
+export { formatCommentsOutput, formatCommentsSummary } from "./comments-render.js";

--- a/src/modules/comments-prepare.ts
+++ b/src/modules/comments-prepare.ts
@@ -100,7 +100,7 @@ function normalizeComments(rawComments: unknown): InternalComment[] {
     }
 
     const rawComment = item as Record<string, unknown>;
-    const id = readOptionalString(rawComment.id);
+    const id = readOptionalIdentifier(rawComment.id);
     if (!id || seenIds.has(id)) {
       continue;
     }
@@ -118,7 +118,7 @@ function normalizeComments(rawComments: unknown): InternalComment[] {
       like_count: readOptionalNumber(rawComment.like_count),
       is_pinned: readOptionalBoolean(rawComment.is_pinned),
       is_favorited: readOptionalBoolean(rawComment.is_favorited),
-      parent: readOptionalString(rawComment.parent) ?? "root",
+      parent: readOptionalIdentifier(rawComment.parent) ?? "root",
       timestamp: readOptionalNumber(rawComment.timestamp),
       time_text: readOptionalString(rawComment.time_text) ?? readOptionalString(rawComment._time_text) ?? null,
       depth: 0,
@@ -184,6 +184,18 @@ function readOptionalString(value: unknown, allowEmpty: boolean = false): string
 
   if (allowEmpty || value.length > 0) {
     return value;
+  }
+
+  return undefined;
+}
+
+function readOptionalIdentifier(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value.length > 0 ? value : undefined;
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
   }
 
   return undefined;

--- a/src/modules/comments-prepare.ts
+++ b/src/modules/comments-prepare.ts
@@ -1,0 +1,198 @@
+import type {
+  NormalizedComment,
+  PreparedComments,
+  ThreadedComment,
+} from "./comments-types.js";
+
+interface InternalComment extends NormalizedComment {
+  is_orphan: boolean;
+}
+
+interface InternalThreadedComment extends InternalComment {
+  replies: InternalThreadedComment[];
+}
+
+export function prepareComments(rawComments: unknown): PreparedComments {
+  const comments = normalizeComments(rawComments);
+  const commentById = new Map<string, InternalComment>();
+
+  for (const comment of comments) {
+    commentById.set(comment.id, comment);
+  }
+
+  const childrenByParent = new Map<string, string[]>();
+  const rootIds: string[] = [];
+
+  for (const comment of comments) {
+    const originalParent = comment.parent;
+    const parentExists = originalParent === "root" || commentById.has(originalParent);
+
+    if (originalParent === comment.id || !parentExists) {
+      comment.parent = "root";
+      comment.is_orphan = originalParent !== "root";
+    }
+
+    if (comment.parent === "root") {
+      rootIds.push(comment.id);
+      continue;
+    }
+
+    const children = childrenByParent.get(comment.parent) ?? [];
+    children.push(comment.id);
+    childrenByParent.set(comment.parent, children);
+  }
+
+  const assigned = new Set<string>();
+  const threadedComments: InternalThreadedComment[] = [];
+
+  for (const rootId of rootIds) {
+    const thread = buildThread(rootId, 0, commentById, childrenByParent, assigned, new Set<string>());
+    if (thread) {
+      threadedComments.push(thread);
+    }
+  }
+
+  for (const comment of comments) {
+    if (assigned.has(comment.id)) {
+      continue;
+    }
+
+    if (comment.parent !== "root") {
+      comment.parent = "root";
+      comment.is_orphan = true;
+    }
+
+    const thread = buildThread(
+      comment.id,
+      0,
+      commentById,
+      childrenByParent,
+      assigned,
+      new Set<string>()
+    );
+    if (thread) {
+      threadedComments.push(thread);
+    }
+  }
+
+  return {
+    detectedCount: comments.length,
+    hasThreading: threadedComments.some((thread) => thread.reply_count > 0),
+    flatComments: comments.map(stripInternalComment),
+    threadedComments: threadedComments.map(stripInternalThread),
+    orphanCommentIds: comments
+      .filter((comment) => comment.is_orphan)
+      .map((comment) => comment.id),
+  };
+}
+
+function normalizeComments(rawComments: unknown): InternalComment[] {
+  if (!Array.isArray(rawComments)) {
+    return [];
+  }
+
+  const seenIds = new Set<string>();
+  const comments: InternalComment[] = [];
+
+  for (const item of rawComments) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      continue;
+    }
+
+    const rawComment = item as Record<string, unknown>;
+    const id = readOptionalString(rawComment.id);
+    if (!id || seenIds.has(id)) {
+      continue;
+    }
+
+    seenIds.add(id);
+
+    comments.push({
+      id,
+      text: readOptionalString(rawComment.text, true),
+      author: readOptionalString(rawComment.author),
+      author_id: readOptionalString(rawComment.author_id),
+      author_url: readOptionalString(rawComment.author_url),
+      author_is_uploader: readOptionalBoolean(rawComment.author_is_uploader),
+      author_is_verified: readOptionalBoolean(rawComment.author_is_verified),
+      like_count: readOptionalNumber(rawComment.like_count),
+      is_pinned: readOptionalBoolean(rawComment.is_pinned),
+      is_favorited: readOptionalBoolean(rawComment.is_favorited),
+      parent: readOptionalString(rawComment.parent) ?? "root",
+      timestamp: readOptionalNumber(rawComment.timestamp),
+      time_text: readOptionalString(rawComment.time_text) ?? readOptionalString(rawComment._time_text) ?? null,
+      depth: 0,
+      reply_count: 0,
+      is_orphan: false,
+    });
+  }
+
+  return comments;
+}
+
+function buildThread(
+  commentId: string,
+  depth: number,
+  commentById: Map<string, InternalComment>,
+  childrenByParent: Map<string, string[]>,
+  assigned: Set<string>,
+  stack: Set<string>
+): InternalThreadedComment | null {
+  const comment = commentById.get(commentId);
+  if (!comment || stack.has(commentId) || assigned.has(commentId)) {
+    return null;
+  }
+
+  assigned.add(commentId);
+  comment.depth = depth;
+
+  const nextStack = new Set(stack);
+  nextStack.add(commentId);
+  const replies: InternalThreadedComment[] = [];
+
+  for (const childId of childrenByParent.get(commentId) ?? []) {
+    const child = buildThread(childId, depth + 1, commentById, childrenByParent, assigned, nextStack);
+    if (child) {
+      replies.push(child);
+    }
+  }
+
+  comment.reply_count = replies.length;
+  return {
+    ...comment,
+    replies,
+  };
+}
+
+function stripInternalComment(comment: InternalComment): NormalizedComment {
+  const { is_orphan: _isOrphan, ...publicComment } = comment;
+  return publicComment;
+}
+
+function stripInternalThread(comment: InternalThreadedComment): ThreadedComment {
+  const { is_orphan: _isOrphan, replies, ...publicComment } = comment;
+  return {
+    ...publicComment,
+    replies: replies.map(stripInternalThread),
+  };
+}
+
+function readOptionalString(value: unknown, allowEmpty: boolean = false): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  if (allowEmpty || value.length > 0) {
+    return value;
+  }
+
+  return undefined;
+}
+
+function readOptionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readOptionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}

--- a/src/modules/comments-render.ts
+++ b/src/modules/comments-render.ts
@@ -10,6 +10,7 @@ import type {
   ThreadedComment,
   ThreadedCommentsResponse,
 } from "./comments-types.js";
+import { countThreadComments } from "./comments-types.js";
 
 interface SelectionResult<TComment> {
   comments: TComment[];
@@ -110,9 +111,8 @@ function serializeFlatResponse(
 ): string {
   let selectedComments = comments;
   let truncated = false;
-  let result = "";
 
-  while (selectedComments.length >= 0) {
+  while (true) {
     const stats = buildFlatStats(selectedComments, orphanIds);
     const response: FlatCommentsResponse = {
       count: stats.count,
@@ -127,7 +127,7 @@ function serializeFlatResponse(
       } : {}),
     };
 
-    result = JSON.stringify(response, null, 2);
+    const result = JSON.stringify(response, null, 2);
     if (!characterLimit || result.length <= characterLimit || selectedComments.length === 0) {
       return result;
     }
@@ -135,8 +135,6 @@ function serializeFlatResponse(
     truncated = true;
     selectedComments = selectedComments.slice(0, -1);
   }
-
-  return result;
 }
 
 function serializeThreadedResponse(
@@ -147,9 +145,8 @@ function serializeThreadedResponse(
 ): string {
   let selectedThreads = comments;
   let truncated = false;
-  let result = "";
 
-  while (selectedThreads.length >= 0) {
+  while (true) {
     const stats = buildThreadedStats(selectedThreads, orphanIds);
     const response: ThreadedCommentsResponse = {
       count: stats.count,
@@ -164,7 +161,7 @@ function serializeThreadedResponse(
       } : {}),
     };
 
-    result = JSON.stringify(response, null, 2);
+    const result = JSON.stringify(response, null, 2);
     if (!characterLimit || result.length <= characterLimit || selectedThreads.length === 0) {
       return result;
     }
@@ -172,8 +169,6 @@ function serializeThreadedResponse(
     truncated = true;
     selectedThreads = selectedThreads.slice(0, -1);
   }
-
-  return result;
 }
 
 function formatMarkdownComments(
@@ -186,10 +181,9 @@ function formatMarkdownComments(
   const baseSelection = selectThreadedComments(prepared.threadedComments, maxComments);
   let selectedThreads = baseSelection.comments;
   let truncated = false;
-  let result = "";
 
-  while (selectedThreads.length >= 0) {
-    result = renderMarkdownDocument(
+  while (true) {
+    const result = renderMarkdownDocument(
       selectedThreads,
       prepared,
       sourceInfo,
@@ -205,8 +199,6 @@ function formatMarkdownComments(
     truncated = true;
     selectedThreads = selectedThreads.slice(0, -1);
   }
-
-  return result;
 }
 
 function renderMarkdownDocument(
@@ -325,9 +317,6 @@ function flattenThreads(comments: ThreadedComment[]): ThreadedComment[] {
   return flattened;
 }
 
-function countThreadComments(comment: ThreadedComment): number {
-  return 1 + comment.replies.reduce((sum, reply) => sum + countThreadComments(reply), 0);
-}
 
 function appendOptionalLine(lines: string[], key: string, value: unknown): void {
   if (value === undefined || value === null) {

--- a/src/modules/comments-render.ts
+++ b/src/modules/comments-render.ts
@@ -1,0 +1,351 @@
+import { prepareComments } from "./comments-prepare.js";
+import { buildFlatSummary, buildThreadedSummary } from "./comments-summary.js";
+import type {
+  CommentRequestOptions,
+  CommentSourceInfo,
+  CommentSummaryOptions,
+  FlatCommentsResponse,
+  NormalizedComment,
+  PreparedComments,
+  ThreadedComment,
+  ThreadedCommentsResponse,
+} from "./comments-types.js";
+
+interface SelectionResult<TComment> {
+  comments: TComment[];
+  hasMore: boolean;
+}
+
+interface SelectedStats {
+  count: number;
+  rootThreads: number;
+  replyComments: number;
+  orphanComments: number;
+}
+
+export function formatCommentsOutput(
+  rawComments: unknown,
+  sourceInfo: CommentSourceInfo,
+  options: CommentRequestOptions,
+  characterLimit?: number
+): string {
+  const prepared = prepareComments(rawComments);
+
+  if (options.responseFormat === "markdown_tree") {
+    return formatMarkdownComments(prepared, sourceInfo, options.maxComments, characterLimit);
+  }
+
+  const orphanIds = new Set(prepared.orphanCommentIds);
+
+  if (options.view === "threaded") {
+    const selection = selectThreadedComments(prepared.threadedComments, options.maxComments);
+    return serializeThreadedResponse(selection.comments, selection.hasMore, orphanIds, characterLimit);
+  }
+
+  const selection = selectFlatComments(prepared.flatComments, options.maxComments);
+  return serializeFlatResponse(selection.comments, selection.hasMore, orphanIds, characterLimit);
+}
+
+export function formatCommentsSummary(rawComments: unknown, options: CommentSummaryOptions): string {
+  const prepared = prepareComments(rawComments);
+
+  if (options.view === "threaded") {
+    const selection = selectThreadedComments(prepared.threadedComments, options.maxComments);
+    return buildThreadedSummary(selection.comments, selection.hasMore);
+  }
+
+  const selection = selectFlatComments(prepared.flatComments, options.maxComments);
+  return buildFlatSummary(selection.comments, selection.hasMore);
+}
+
+function selectFlatComments(
+  comments: NormalizedComment[],
+  maxComments: number
+): SelectionResult<NormalizedComment> {
+  const limitedComments = comments.slice(0, maxComments);
+  return {
+    comments: limitedComments,
+    hasMore: comments.length > limitedComments.length,
+  };
+}
+
+function selectThreadedComments(
+  comments: ThreadedComment[],
+  maxComments: number
+): SelectionResult<ThreadedComment> {
+  const selected: ThreadedComment[] = [];
+  let selectedCount = 0;
+
+  for (const thread of comments) {
+    const threadCount = countThreadComments(thread);
+    if (selected.length > 0 && selectedCount + threadCount > maxComments) {
+      return {
+        comments: selected,
+        hasMore: true,
+      };
+    }
+
+    selected.push(thread);
+    selectedCount += threadCount;
+
+    if (selectedCount >= maxComments) {
+      return {
+        comments: selected,
+        hasMore: selected.length < comments.length,
+      };
+    }
+  }
+
+  return {
+    comments: selected,
+    hasMore: selected.length < comments.length,
+  };
+}
+
+function serializeFlatResponse(
+  comments: NormalizedComment[],
+  hasMore: boolean,
+  orphanIds: Set<string>,
+  characterLimit?: number
+): string {
+  let selectedComments = comments;
+  let truncated = false;
+  let result = "";
+
+  while (selectedComments.length >= 0) {
+    const stats = buildFlatStats(selectedComments, orphanIds);
+    const response: FlatCommentsResponse = {
+      count: stats.count,
+      has_more: hasMore || truncated,
+      root_threads: stats.rootThreads,
+      reply_comments: stats.replyComments,
+      orphan_comments: stats.orphanComments,
+      comments: selectedComments,
+      ...(truncated ? {
+        _truncated: true,
+        _message: `Response truncated to ${selectedComments.length} comments due to size limits.`,
+      } : {}),
+    };
+
+    result = JSON.stringify(response, null, 2);
+    if (!characterLimit || result.length <= characterLimit || selectedComments.length === 0) {
+      return result;
+    }
+
+    truncated = true;
+    selectedComments = selectedComments.slice(0, -1);
+  }
+
+  return result;
+}
+
+function serializeThreadedResponse(
+  comments: ThreadedComment[],
+  hasMore: boolean,
+  orphanIds: Set<string>,
+  characterLimit?: number
+): string {
+  let selectedThreads = comments;
+  let truncated = false;
+  let result = "";
+
+  while (selectedThreads.length >= 0) {
+    const stats = buildThreadedStats(selectedThreads, orphanIds);
+    const response: ThreadedCommentsResponse = {
+      count: stats.count,
+      has_more: hasMore || truncated,
+      root_threads: stats.rootThreads,
+      reply_comments: stats.replyComments,
+      orphan_comments: stats.orphanComments,
+      comments: selectedThreads,
+      ...(truncated ? {
+        _truncated: true,
+        _message: `Response truncated to ${selectedThreads.length} threads due to size limits.`,
+      } : {}),
+    };
+
+    result = JSON.stringify(response, null, 2);
+    if (!characterLimit || result.length <= characterLimit || selectedThreads.length === 0) {
+      return result;
+    }
+
+    truncated = true;
+    selectedThreads = selectedThreads.slice(0, -1);
+  }
+
+  return result;
+}
+
+function formatMarkdownComments(
+  prepared: PreparedComments,
+  sourceInfo: CommentSourceInfo,
+  maxComments: number,
+  characterLimit?: number
+): string {
+  const orphanIds = new Set(prepared.orphanCommentIds);
+  const baseSelection = selectThreadedComments(prepared.threadedComments, maxComments);
+  let selectedThreads = baseSelection.comments;
+  let truncated = false;
+  let result = "";
+
+  while (selectedThreads.length >= 0) {
+    result = renderMarkdownDocument(
+      selectedThreads,
+      prepared,
+      sourceInfo,
+      orphanIds,
+      baseSelection.hasMore || truncated,
+      truncated
+    );
+
+    if (!characterLimit || result.length <= characterLimit || selectedThreads.length === 0) {
+      return result;
+    }
+
+    truncated = true;
+    selectedThreads = selectedThreads.slice(0, -1);
+  }
+
+  return result;
+}
+
+function renderMarkdownDocument(
+  comments: ThreadedComment[],
+  prepared: PreparedComments,
+  sourceInfo: CommentSourceInfo,
+  orphanIds: Set<string>,
+  hasMore: boolean,
+  truncated: boolean
+): string {
+  const stats = buildThreadedStats(comments, orphanIds);
+  const generatedAtUtc = sourceInfo.generatedAtUtc ?? new Date().toISOString();
+  const headerLines = [
+    "# AI-Ready Comment Threads",
+    "",
+    `source_title: ${formatScalar(sourceInfo.title ?? null)}`,
+    `source_id: ${formatScalar(sourceInfo.sourceId ?? null)}`,
+    `source_url: ${formatScalar(sourceInfo.sourceUrl ?? null)}`,
+    `extractor: ${formatScalar(sourceInfo.extractor ?? null)}`,
+    `generated_at_utc: ${formatScalar(generatedAtUtc)}`,
+    `raw_info_json: ${formatScalar(sourceInfo.rawInfoJsonPath ?? null)}`,
+    `comments_detected: ${prepared.detectedCount}`,
+    `comments_returned: ${stats.count}`,
+    `root_threads: ${stats.rootThreads}`,
+    `reply_comments: ${stats.replyComments}`,
+    `orphan_comments: ${stats.orphanComments}`,
+    `has_threading: ${formatScalar(prepared.hasThreading)}`,
+    `has_more: ${formatScalar(hasMore)}`,
+    "",
+    "## Notes",
+    "",
+    "- Optimized for LLMs with stable keys, explicit `parent_id`, and preserved thread structure.",
+    "- If the extractor does not expose `parent`, every comment is treated as a root thread.",
+    "- `orphan_comments` means a reply arrived without its parent in the fetched payload.",
+  ];
+
+  if (truncated) {
+    headerLines.push("- Output was truncated by whole thread blocks to fit MCP size limits.");
+  }
+
+  headerLines.push("", "## Threads", "");
+
+  if (comments.length === 0) {
+    headerLines.push("No comments were available in the extracted payload.", "");
+    return `${headerLines.join("\n")}`.trimEnd() + "\n";
+  }
+
+  const threadBlocks = comments.map((thread, index) => renderThreadBlock(thread, index + 1));
+  return `${headerLines.join("\n")}\n${threadBlocks.join("")}`.trimEnd() + "\n";
+}
+
+function renderThreadBlock(thread: ThreadedComment, index: number): string {
+  const lines = [`### Thread ${index}`, ""];
+  appendThreadLines(thread, 0, lines);
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+function appendThreadLines(comment: ThreadedComment, depth: number, lines: string[]): void {
+  const indent = "  ".repeat(depth);
+
+  lines.push(`${indent}- comment_id: ${formatScalar(comment.id)}`);
+  lines.push(`${indent}  parent_id: ${formatScalar(comment.parent)}`);
+  lines.push(`${indent}  depth: ${comment.depth}`);
+
+  appendOptionalLine(lines, `${indent}  author`, comment.author);
+  appendOptionalLine(lines, `${indent}  author_id`, comment.author_id);
+  appendOptionalLine(lines, `${indent}  author_url`, comment.author_url);
+  appendOptionalLine(lines, `${indent}  author_is_uploader`, comment.author_is_uploader);
+  appendOptionalLine(lines, `${indent}  author_is_verified`, comment.author_is_verified);
+  appendOptionalLine(lines, `${indent}  is_pinned`, comment.is_pinned);
+  appendOptionalLine(lines, `${indent}  is_favorited`, comment.is_favorited);
+  appendOptionalLine(lines, `${indent}  like_count`, comment.like_count);
+  appendOptionalLine(lines, `${indent}  timestamp`, comment.timestamp);
+  appendOptionalLine(lines, `${indent}  time_text`, comment.time_text);
+
+  lines.push(`${indent}  reply_count: ${comment.reply_count}`);
+  lines.push(`${indent}  text:`);
+  appendTextBlock(lines, `${indent}    `, comment.text ?? "");
+
+  for (const reply of comment.replies) {
+    appendThreadLines(reply, depth + 1, lines);
+  }
+}
+
+function buildFlatStats(comments: NormalizedComment[], orphanIds: Set<string>): SelectedStats {
+  const rootThreads = comments.filter((comment) => comment.parent === "root").length;
+  const orphanComments = comments.filter((comment) => orphanIds.has(comment.id)).length;
+
+  return {
+    count: comments.length,
+    rootThreads,
+    replyComments: Math.max(0, comments.length - rootThreads),
+    orphanComments,
+  };
+}
+
+function buildThreadedStats(comments: ThreadedComment[], orphanIds: Set<string>): SelectedStats {
+  const flatComments = flattenThreads(comments);
+  return {
+    count: flatComments.length,
+    rootThreads: comments.length,
+    replyComments: Math.max(0, flatComments.length - comments.length),
+    orphanComments: flatComments.filter((comment) => orphanIds.has(comment.id)).length,
+  };
+}
+
+function flattenThreads(comments: ThreadedComment[]): ThreadedComment[] {
+  const flattened: ThreadedComment[] = [];
+
+  for (const comment of comments) {
+    flattened.push(comment);
+    flattened.push(...flattenThreads(comment.replies));
+  }
+
+  return flattened;
+}
+
+function countThreadComments(comment: ThreadedComment): number {
+  return 1 + comment.replies.reduce((sum, reply) => sum + countThreadComments(reply), 0);
+}
+
+function appendOptionalLine(lines: string[], key: string, value: unknown): void {
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  lines.push(`${key}: ${formatScalar(value)}`);
+}
+
+function appendTextBlock(lines: string[], indent: string, text: string): void {
+  const textLines = text.split("\n");
+  const normalizedLines = textLines.length > 0 ? textLines : [""];
+
+  for (const line of normalizedLines) {
+    lines.push(line ? `${indent}| ${line}` : `${indent}|`);
+  }
+}
+
+function formatScalar(value: unknown): string {
+  return JSON.stringify(value);
+}

--- a/src/modules/comments-summary.ts
+++ b/src/modules/comments-summary.ts
@@ -1,0 +1,102 @@
+import type {
+  NormalizedComment,
+  ThreadedComment,
+} from "./comments-types.js";
+
+export function buildFlatSummary(comments: NormalizedComment[], hasMore: boolean): string {
+  const lines: string[] = [];
+
+  lines.push(`Video Comments (${comments.length} shown)`);
+  lines.push("─".repeat(30));
+  lines.push("");
+
+  for (const comment of comments) {
+    if (comment.parent !== "root") {
+      lines.push(`Reply to: ${comment.parent}`);
+    }
+
+    lines.push(buildAuthorLine(comment, "Author"));
+    if (comment.text) {
+      lines.push(truncateCommentText(comment.text));
+    }
+    lines.push("");
+  }
+
+  if (hasMore) {
+    lines.push("---");
+    lines.push("More comments available. Increase maxComments to see more.");
+  }
+
+  return lines.join("\n");
+}
+
+export function buildThreadedSummary(comments: ThreadedComment[], hasMore: boolean): string {
+  const lines: string[] = [];
+  const totalCount = comments.reduce((sum, thread) => sum + countThreadComments(thread), 0);
+
+  lines.push(`Video Comments (${totalCount} shown across ${comments.length} threads)`);
+  lines.push("─".repeat(30));
+  lines.push("");
+
+  comments.forEach((thread, index) => {
+    lines.push(`Thread ${index + 1}`);
+    appendThreadSummary(thread, 0, lines);
+    lines.push("");
+  });
+
+  if (hasMore) {
+    lines.push("---");
+    lines.push("More comments available. Increase maxComments to see more.");
+  }
+
+  return lines.join("\n");
+}
+
+function appendThreadSummary(comment: ThreadedComment, depth: number, lines: string[]): void {
+  const indent = "  ".repeat(depth);
+  const label = depth === 0 ? "Author" : "Reply";
+
+  lines.push(`${indent}${buildAuthorLine(comment, label)}`);
+  if (comment.text) {
+    lines.push(`${indent}${truncateCommentText(comment.text)}`);
+  }
+  lines.push("");
+
+  for (const reply of comment.replies) {
+    appendThreadSummary(reply, depth + 1, lines);
+  }
+}
+
+function buildAuthorLine(comment: NormalizedComment, prefix: string): string {
+  let line = `${prefix}: ${comment.author ?? "Unknown"}`;
+
+  if (comment.author_is_uploader) {
+    line += " [UPLOADER]";
+  }
+  if (comment.author_is_verified) {
+    line += " [VERIFIED]";
+  }
+  if (comment.is_pinned) {
+    line += " [PINNED]";
+  }
+  if (comment.time_text) {
+    line += ` (${comment.time_text})`;
+  }
+  if (typeof comment.like_count === "number" && comment.like_count > 0) {
+    line += ` - ${comment.like_count.toLocaleString()} likes`;
+  }
+
+  return line;
+}
+
+function truncateCommentText(text: string): string {
+  if (text.length <= 300) {
+    return text;
+  }
+
+  return `${text.slice(0, 300)}...`;
+}
+
+function countThreadComments(comment: ThreadedComment): number {
+  return 1 + comment.replies.reduce((sum, reply) => sum + countThreadComments(reply), 0);
+}

--- a/src/modules/comments-summary.ts
+++ b/src/modules/comments-summary.ts
@@ -2,6 +2,7 @@ import type {
   NormalizedComment,
   ThreadedComment,
 } from "./comments-types.js";
+import { countThreadComments } from "./comments-types.js";
 
 export function buildFlatSummary(comments: NormalizedComment[], hasMore: boolean): string {
   const lines: string[] = [];
@@ -95,8 +96,4 @@ function truncateCommentText(text: string): string {
   }
 
   return `${text.slice(0, 300)}...`;
-}
-
-function countThreadComments(comment: ThreadedComment): number {
-  return 1 + comment.replies.reduce((sum, reply) => sum + countThreadComments(reply), 0);
 }

--- a/src/modules/comments-types.ts
+++ b/src/modules/comments-types.ts
@@ -98,6 +98,10 @@ export function buildCommentExtractorArgs(options: CommentRequestOptions): strin
   return `youtube:comment_sort=${options.sortOrder};max_comments=${options.maxComments},${options.maxParents},${options.maxReplies},${options.maxRepliesPerThread},${options.maxDepth}`;
 }
 
+export function countThreadComments(comment: ThreadedComment): number {
+  return 1 + comment.replies.reduce((sum, reply) => sum + countThreadComments(reply), 0);
+}
+
 function clampInteger(value: number, minimum: number): number {
   return Math.max(minimum, Math.trunc(value));
 }

--- a/src/modules/comments-types.ts
+++ b/src/modules/comments-types.ts
@@ -1,0 +1,103 @@
+export interface Comment {
+  id?: string;
+  text?: string;
+  author?: string;
+  author_id?: string;
+  author_url?: string;
+  author_is_uploader?: boolean;
+  author_is_verified?: boolean;
+  like_count?: number;
+  is_pinned?: boolean;
+  is_favorited?: boolean;
+  parent?: string;
+  timestamp?: number;
+  time_text?: string | null;
+  [key: string]: unknown;
+}
+
+export interface NormalizedComment extends Comment {
+  id: string;
+  parent: string;
+  time_text: string | null;
+  depth: number;
+  reply_count: number;
+}
+
+export interface ThreadedComment extends NormalizedComment {
+  replies: ThreadedComment[];
+}
+
+export interface CommentsResponseBase<TComment> {
+  count: number;
+  has_more: boolean;
+  root_threads: number;
+  reply_comments: number;
+  orphan_comments: number;
+  comments: TComment[];
+  _truncated?: boolean;
+  _message?: string;
+}
+
+export type FlatCommentsResponse = CommentsResponseBase<NormalizedComment>;
+export type ThreadedCommentsResponse = CommentsResponseBase<ThreadedComment>;
+export type CommentsResponse = FlatCommentsResponse | ThreadedCommentsResponse;
+export type CommentSortOrder = "top" | "new";
+export type CommentView = "flat" | "threaded";
+export type CommentResponseFormat = "json" | "markdown_tree";
+
+export interface CommentRequestOptions {
+  maxComments: number;
+  sortOrder: CommentSortOrder;
+  view: CommentView;
+  responseFormat: CommentResponseFormat;
+  maxParents: number;
+  maxReplies: number;
+  maxRepliesPerThread: number;
+  maxDepth: number;
+}
+
+export interface CommentSummaryOptions {
+  maxComments: number;
+  view: CommentView;
+}
+
+export interface CommentSourceInfo {
+  sourceId?: string | null;
+  title?: string | null;
+  sourceUrl?: string | null;
+  extractor?: string | null;
+  rawInfoJsonPath?: string | null;
+  generatedAtUtc?: string;
+}
+
+export interface PreparedComments {
+  detectedCount: number;
+  hasThreading: boolean;
+  flatComments: NormalizedComment[];
+  threadedComments: ThreadedComment[];
+  orphanCommentIds: string[];
+}
+
+export function resolveCommentRequestOptions(
+  input: Partial<CommentRequestOptions> & Pick<CommentRequestOptions, "maxComments">
+): CommentRequestOptions {
+  const maxComments = clampInteger(input.maxComments, 1);
+  return {
+    maxComments,
+    sortOrder: input.sortOrder ?? "top",
+    view: input.view ?? "flat",
+    responseFormat: input.responseFormat ?? "json",
+    maxParents: clampInteger(input.maxParents ?? maxComments, 0),
+    maxReplies: clampInteger(input.maxReplies ?? maxComments, 0),
+    maxRepliesPerThread: clampInteger(input.maxRepliesPerThread ?? maxComments, 0),
+    maxDepth: clampInteger(input.maxDepth ?? 2, 1),
+  };
+}
+
+export function buildCommentExtractorArgs(options: CommentRequestOptions): string {
+  return `youtube:comment_sort=${options.sortOrder};max_comments=${options.maxComments},${options.maxParents},${options.maxReplies},${options.maxRepliesPerThread},${options.maxDepth}`;
+}
+
+function clampInteger(value: number, minimum: number): number {
+  return Math.max(minimum, Math.trunc(value));
+}

--- a/src/modules/comments.ts
+++ b/src/modules/comments.ts
@@ -45,10 +45,18 @@ export async function getVideoComments(
     throw new Error("Invalid or unsupported URL format");
   }
 
+  const normalizedView = options.responseFormat === "markdown_tree"
+    ? options.view ?? "threaded"
+    : options.view;
+
+  if (options.responseFormat === "markdown_tree" && normalizedView !== "threaded") {
+    throw new Error("responseFormat 'markdown_tree' requires view 'threaded'. Omit view to use the threaded default.");
+  }
+
   const requestOptions = resolveCommentRequestOptions({
     maxComments,
     sortOrder,
-    view: options.view,
+    view: normalizedView,
     responseFormat: options.responseFormat,
     maxParents: options.maxParents,
     maxReplies: options.maxReplies,

--- a/src/modules/comments.ts
+++ b/src/modules/comments.ts
@@ -1,283 +1,159 @@
 import type { Config } from "../config.js";
 import { getCookieArgs } from "../config.js";
+import { _spawnPromise, validateUrl } from "./utils.js";
 import {
-  _spawnPromise,
-  validateUrl
-} from "./utils.js";
+  buildCommentExtractorArgs,
+  formatCommentsOutput,
+  formatCommentsSummary,
+  resolveCommentRequestOptions,
+} from "./comments-core.js";
 
-/**
- * Represents a single comment on a video
- */
-export interface Comment {
-  /** Unique comment identifier */
-  id?: string;
-  /** Comment text content */
-  text?: string;
-  /** Comment author name */
-  author?: string;
-  /** Comment author channel ID */
-  author_id?: string;
-  /** Comment author channel URL */
-  author_url?: string;
-  /** Whether the author is the video uploader */
-  author_is_uploader?: boolean;
-  /** Whether author is verified */
-  author_is_verified?: boolean;
-  /** Comment like count */
-  like_count?: number;
-  /** Whether comment is pinned */
-  is_pinned?: boolean;
-  /** Whether comment is marked as favorite by uploader */
-  is_favorited?: boolean;
-  /** Parent comment ID (for replies) */
-  parent?: string;
-  /** Unix timestamp of comment */
-  timestamp?: number;
-  /** Human-readable time ago string */
-  time_text?: string;
-  /** Additional fields that might be present */
-  [key: string]: unknown;
+export type {
+  Comment,
+  CommentsResponse,
+  CommentResponseFormat,
+  CommentSortOrder,
+  CommentSummaryOptions,
+  CommentView,
+  FlatCommentsResponse,
+  NormalizedComment,
+  ThreadedComment,
+  ThreadedCommentsResponse,
+} from "./comments-core.js";
+
+export interface GetVideoCommentsOptions {
+  view?: "flat" | "threaded";
+  responseFormat?: "json" | "markdown_tree";
+  maxParents?: number;
+  maxReplies?: number;
+  maxRepliesPerThread?: number;
+  maxDepth?: number;
 }
 
-/**
- * Response structure for video comments
- */
-export interface CommentsResponse {
-  /** Total number of comments returned */
-  count: number;
-  /** Whether there are more comments available */
-  has_more: boolean;
-  /** Array of comment objects */
-  comments: Comment[];
-  /** Truncation indicator */
-  _truncated?: boolean;
-  /** Truncation message */
-  _message?: string;
+export interface GetVideoCommentsSummaryOptions {
+  view?: "flat" | "threaded";
 }
 
-/**
- * Sort order for comments
- */
-export type CommentSortOrder = "top" | "new";
-
-/**
- * Extract video comments using yt-dlp.
- * Uses yt-dlp's --write-comments and --dump-json flags to get comments.
- *
- * @param url - The URL of the video to extract comments from
- * @param maxComments - Maximum number of comments to retrieve (default: 20)
- * @param sortOrder - Sort order: "top" for most liked, "new" for newest (default: "top")
- * @param config - Configuration object
- * @returns Promise resolving to JSON string with comments data
- * @throws {Error} When URL is invalid or comment extraction fails
- *
- * @example
- * ```typescript
- * // Get top 20 comments
- * const comments = await getVideoComments('https://youtube.com/watch?v=...');
- * console.log(comments);
- *
- * // Get newest 50 comments
- * const newComments = await getVideoComments(
- *   'https://youtube.com/watch?v=...',
- *   50,
- *   'new'
- * );
- * ```
- */
 export async function getVideoComments(
   url: string,
   maxComments: number = 20,
-  sortOrder: CommentSortOrder = "top",
-  _config?: Config
+  sortOrder: "top" | "new" = "top",
+  config?: Config,
+  options: GetVideoCommentsOptions = {}
 ): Promise<string> {
-  // Validate the URL
   if (!validateUrl(url)) {
     throw new Error("Invalid or unsupported URL format");
   }
+
+  const requestOptions = resolveCommentRequestOptions({
+    maxComments,
+    sortOrder,
+    view: options.view,
+    responseFormat: options.responseFormat,
+    maxParents: options.maxParents,
+    maxReplies: options.maxReplies,
+    maxRepliesPerThread: options.maxRepliesPerThread,
+    maxDepth: options.maxDepth,
+  });
 
   const args = [
     "--dump-json",
     "--no-warnings",
     "--no-check-certificate",
     "--write-comments",
-    "--extractor-args", `youtube:comment_sort=${sortOrder};max_comments=${maxComments},all,all`,
+    "--extractor-args",
+    buildCommentExtractorArgs(requestOptions),
     "--skip-download",
-    ...(_config ? getCookieArgs(_config) : []),
-    url
+    ...(config ? getCookieArgs(config) : []),
+    url,
   ];
 
   try {
-    // Execute yt-dlp to get metadata with comments
     const output = await _spawnPromise("yt-dlp", args);
+    const metadata = JSON.parse(output) as Record<string, unknown>;
 
-    // Parse the JSON output
-    const metadata = JSON.parse(output);
-
-    // Extract comments from metadata
-    const rawComments: Comment[] = metadata.comments || [];
-
-    // Limit to maxComments
-    const comments = rawComments.slice(0, maxComments);
-
-    // Build response
-    const response: CommentsResponse = {
-      count: comments.length,
-      has_more: rawComments.length > maxComments,
-      comments: comments.map(comment => ({
-        id: comment.id,
-        text: comment.text,
-        author: comment.author,
-        author_id: comment.author_id,
-        author_url: comment.author_url,
-        author_is_uploader: comment.author_is_uploader,
-        author_is_verified: comment.author_is_verified,
-        like_count: comment.like_count,
-        is_pinned: comment.is_pinned,
-        is_favorited: comment.is_favorited,
-        parent: comment.parent,
-        timestamp: comment.timestamp,
-        time_text: comment.time_text
-      }))
-    };
-
-    let result = JSON.stringify(response, null, 2);
-
-    // Check character limit
-    if (_config && result.length > _config.limits.characterLimit) {
-      // Reduce comments to fit within limit
-      let truncatedComments = [...response.comments];
-
-      while (result.length > _config.limits.characterLimit && truncatedComments.length > 1) {
-        truncatedComments = truncatedComments.slice(0, -1);
-        const truncatedResponse: CommentsResponse = {
-          count: truncatedComments.length,
-          has_more: true,
-          comments: truncatedComments,
-          _truncated: true,
-          _message: `Response truncated to ${truncatedComments.length} comments due to size limits. Use smaller maxComments value.`
-        };
-        result = JSON.stringify(truncatedResponse, null, 2);
-      }
-    }
-
-    return result;
-
+    return formatCommentsOutput(
+      metadata.comments,
+      {
+        sourceId: readMetadataString(metadata.id),
+        title: readMetadataString(metadata.title) ?? readMetadataString(metadata.fulltitle),
+        sourceUrl: readMetadataString(metadata.webpage_url) ?? readMetadataString(metadata.original_url) ?? url,
+        extractor: readMetadataString(metadata.extractor_key) ?? readMetadataString(metadata.extractor),
+      },
+      requestOptions,
+      config?.limits.characterLimit
+    );
   } catch (error) {
-    if (error instanceof Error) {
-      // Handle common yt-dlp errors with actionable messages
-      if (error.message.includes("Video unavailable") || error.message.includes("private")) {
-        throw new Error(`Video is unavailable or private: ${url}. Check the URL and video privacy settings.`);
-      } else if (error.message.includes("Unsupported URL") || error.message.includes("extractor")) {
-        throw new Error(`Unsupported platform or video URL: ${url}. Comments extraction is primarily supported for YouTube.`);
-      } else if (error.message.includes("network") || error.message.includes("Connection")) {
-        throw new Error("Network error while extracting comments. Check your internet connection and retry.");
-      } else if (error.message.includes("comments are disabled") || error.message.includes("Comments are turned off")) {
-        throw new Error(`Comments are disabled for this video: ${url}`);
-      } else if (error.message.includes("Sign in") || error.message.includes("age")) {
-        throw new Error(`This video requires authentication to view comments. Configure cookies in your settings.`);
-      } else {
-        throw new Error(`Failed to extract video comments: ${error.message}. Verify the URL is correct.`);
-      }
-    }
-    throw new Error(`Failed to extract video comments from ${url}`);
+    handleCommentsError(error, url);
   }
 }
 
-/**
- * Get a human-readable summary of video comments.
- * This is useful for quick overview without overwhelming JSON output.
- *
- * @param url - The URL of the video to extract comments from
- * @param maxComments - Maximum number of comments to include (default: 10)
- * @param config - Configuration object
- * @returns Promise resolving to a formatted summary string
- * @throws {Error} When URL is invalid or comment extraction fails
- *
- * @example
- * ```typescript
- * const summary = await getVideoCommentsSummary('https://youtube.com/watch?v=...');
- * console.log(summary);
- * // Output:
- * // Video Comments (10 shown)
- * // ─────────────────────────
- * //
- * // 👤 John Doe (2 days ago) ❤️ 1,234 likes
- * // This is an awesome video!
- * //
- * // 👤 Jane Smith (1 week ago) ❤️ 567 likes
- * // Great content, keep it up!
- * ```
- */
 export async function getVideoCommentsSummary(
   url: string,
   maxComments: number = 10,
-  _config?: Config
+  config?: Config,
+  options: GetVideoCommentsSummaryOptions = {}
 ): Promise<string> {
-  try {
-    // Get the comments
-    const commentsJson = await getVideoComments(url, maxComments, "top", _config);
-    const data: CommentsResponse = JSON.parse(commentsJson);
-
-    // Format comments into a readable summary
-    const lines: string[] = [];
-
-    lines.push(`Video Comments (${data.count} shown)`);
-    lines.push('─'.repeat(30));
-    lines.push('');
-
-    for (const comment of data.comments) {
-      // Build author line with indicators
-      let authorLine = `Author: ${comment.author || 'Unknown'}`;
-      if (comment.author_is_uploader) {
-        authorLine += ' [UPLOADER]';
-      }
-      if (comment.author_is_verified) {
-        authorLine += ' [VERIFIED]';
-      }
-      if (comment.is_pinned) {
-        authorLine += ' [PINNED]';
-      }
-
-      // Time info
-      if (comment.time_text) {
-        authorLine += ` (${comment.time_text})`;
-      }
-
-      // Likes
-      if (comment.like_count !== undefined && comment.like_count > 0) {
-        authorLine += ` - ${comment.like_count.toLocaleString()} likes`;
-      }
-
-      lines.push(authorLine);
-
-      // Comment text (truncate if too long)
-      if (comment.text) {
-        const text = comment.text.length > 300
-          ? comment.text.substring(0, 300) + '...'
-          : comment.text;
-        lines.push(text);
-      }
-
-      // Note if this is a reply
-      if (comment.parent && comment.parent !== 'root') {
-        lines.push(`(Reply to comment ${comment.parent})`);
-      }
-
-      lines.push('');
-    }
-
-    if (data.has_more) {
-      lines.push('---');
-      lines.push('More comments available. Increase maxComments to see more.');
-    }
-
-    return lines.join('\n');
-  } catch (error) {
-    // Re-throw errors from getVideoComments with context
-    if (error instanceof Error) {
-      throw error;
-    }
-    throw new Error(`Failed to generate comments summary for ${url}`);
+  if (!validateUrl(url)) {
+    throw new Error("Invalid or unsupported URL format");
   }
+
+  const requestOptions = resolveCommentRequestOptions({
+    maxComments,
+    view: options.view,
+  });
+
+  const args = [
+    "--dump-json",
+    "--no-warnings",
+    "--no-check-certificate",
+    "--write-comments",
+    "--extractor-args",
+    buildCommentExtractorArgs(requestOptions),
+    "--skip-download",
+    ...(config ? getCookieArgs(config) : []),
+    url,
+  ];
+
+  try {
+    const output = await _spawnPromise("yt-dlp", args);
+    const metadata = JSON.parse(output) as Record<string, unknown>;
+    return formatCommentsSummary(metadata.comments, {
+      maxComments: requestOptions.maxComments,
+      view: requestOptions.view,
+    });
+  } catch (error) {
+    handleCommentsError(error, url);
+  }
+}
+
+function readMetadataString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function handleCommentsError(error: unknown, url: string): never {
+  if (error instanceof Error) {
+    if (error.message.includes("Video unavailable") || error.message.includes("private")) {
+      throw new Error(`Video is unavailable or private: ${url}. Check the URL and video privacy settings.`);
+    }
+    if (error.message.includes("Unsupported URL") || error.message.includes("extractor")) {
+      throw new Error(`Unsupported platform or video URL: ${url}. Comments extraction is primarily supported for YouTube.`);
+    }
+    if (error.message.includes("network") || error.message.includes("Connection")) {
+      throw new Error("Network error while extracting comments. Check your internet connection and retry.");
+    }
+    if (error.message.includes("comments are disabled") || error.message.includes("Comments are turned off")) {
+      throw new Error(`Comments are disabled for this video: ${url}`);
+    }
+    if (error.message.includes("Sign in") || error.message.includes("age")) {
+      throw new Error(`This video requires authentication to view comments. Configure cookies in your settings.`);
+    }
+    if (error.message.includes("Unexpected token") || error.message.includes("JSON")) {
+      throw new Error(`Failed to parse comments metadata from ${url}. yt-dlp returned invalid JSON output.`);
+    }
+
+    throw new Error(`Failed to extract video comments: ${error.message}. Verify the URL is correct.`);
+  }
+
+  throw new Error(`Failed to extract video comments from ${url}`);
 }


### PR DESCRIPTION
## Summary

This PR overhauls the comments pipeline in `yt-dlp-mcp` while preserving backward-compatible defaults.

It keeps the existing tools:
- `ytdlp_get_video_comments`
- `ytdlp_get_video_comments_summary`

and adds new optional capabilities:
- threaded JSON output
- AI-friendly `markdown_tree` output
- normalized `time_text`
- orphan reply lifting
- full YouTube extractor tuple support for parents/replies/depth

Default behavior remains unchanged:
- `view="flat"`
- `responseFormat="json"`
- `sortOrder="top"`

## What changed

### Comments pipeline
- replaced the old flat-only post-processing flow with normalization, thread reconstruction, and format-specific rendering
- normalize `time_text` from `comment.time_text ?? comment._time_text ?? null`
- require unique comment ids and drop duplicates
- treat self-referential or missing parents as orphan replies and lift them to `root`
- compute `depth` and `reply_count`

### Public interface
`ytdlp_get_video_comments` now supports:
- `view: "flat" | "threaded"`
- `responseFormat: "json" | "markdown_tree"`
- `maxParents`
- `maxReplies`
- `maxRepliesPerThread`
- `maxDepth`

JSON responses now also include:
- `root_threads`
- `reply_comments`
- `orphan_comments`

`ytdlp_get_video_comments_summary` now supports:
- `view: "flat" | "threaded"`

Threaded summaries group replies hierarchically instead of only printing raw parent ids.

### Graceful degradation
For platforms that do not expose `parent` metadata, threaded mode still works and degrades to root-only comments rather than failing.

### Truncation
Character-limit truncation now preserves unit boundaries:
- flat JSON truncates by whole comments
- threaded JSON truncates by whole root threads
- markdown_tree truncates by whole thread blocks

## Tests
Added fixture-based comments coverage for:
- normalization and duplicate handling
- `_time_text` fallback
- threaded tree reconstruction
- orphan lifting
- markdown_tree rendering
- whole-thread truncation
- non-threaded platform degradation
- threaded summary rendering

Live YouTube integration checks remain opt-in via `RUN_INTEGRATION_TESTS=1`.

## Verification
- `npm run prepare`
- `npm test -- --runInBand src/__tests__/comments.test.ts`
- `npm test -- --runTestsByPath src/__tests__/config.test.ts`
- manual smoke against YouTube for threaded JSON, `markdown_tree`, threaded summary, and root-only mode

## Docs
Updated:
- `README.md`
- `docs/api.md`
- `CLAUDE.md`
- `CHANGELOG.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the comment extraction/rendering path and public tool schemas, which can affect downstream consumers and response size/truncation behavior, though defaults remain backward compatible.
> 
> **Overview**
> Adds a new comments processing pipeline that can return **threaded comment trees** and an **AI-friendly `markdown_tree` export**, while keeping the default `view="flat"`/`responseFormat="json"` behavior.
> 
> `ytdlp_get_video_comments` and `ytdlp_get_video_comments_summary` now accept `view` (`flat|threaded`), with `get_video_comments` also gaining `responseFormat` plus YouTube extractor tuple controls (`maxParents`, `maxReplies`, `maxRepliesPerThread`, `maxDepth`); JSON responses now include `root_threads`, `reply_comments`, and `orphan_comments`, and normalization reconstructs threads (dedupe, `time_text` fallback, orphan lifting, `depth`/`reply_count`) with truncation done by whole comments/threads.
> 
> Updates docs (README/API/CLAUDE/CHANGELOG) and replaces network-only comment tests with fixture-based coverage, keeping integration tests opt-in.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76eca3f1804fb045ad056b66df1f6a6d3f17a0d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->