### PR TITLE
fix: publish JSON Schema (not raw Zod) for tool `inputSchema`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Critical**: Tool `inputSchema` was being published as raw Zod schema objects, which `@modelcontextprotocol/sdk@0.7.0` does not auto-convert. Combined with the move to `zod@^4.1.12`, this caused clients to receive empty input schemas (`{ properties: {} }`) and strip all arguments before calling tools — surfacing as `expected string, received undefined` validation errors on every call. Added a `toJsonSchema()` helper using Zod v4's built-in `z.toJSONSchema()` and wrapped all 10 tool registrations.
+
 ---
 
 ## [0.8.4] - 2026-01-04

--- a/src/index.mts
+++ b/src/index.mts
@@ -8,6 +8,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import type { CallToolRequest } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
+import type { ZodType } from "zod";
 
 import * as os from "os";
 import * as fs from "fs";
@@ -155,6 +156,26 @@ const GetVideoCommentsSummarySchema = z.object({
 }).strict();
 
 /**
+ * Convert a Zod schema to a JSON Schema for use as an MCP tool `inputSchema`.
+ *
+ * The MCP protocol requires `inputSchema` to be a JSON Schema object. The
+ * older @modelcontextprotocol/sdk (0.7.x) does not auto-convert Zod schemas,
+ * so passing a raw Zod object would publish an empty schema to clients and
+ * cause every tool call to arrive with `arguments` stripped to `{}` (which
+ * surfaces as `expected string, received undefined` validation errors).
+ *
+ * Zod v4 ships `z.toJSONSchema()` natively, so no extra dependency is needed.
+ * We strip the `$schema` field because the MCP client validates against the
+ * raw structural schema and some clients reject unknown top-level keys.
+ */
+function toJsonSchema(schema: ZodType): Record<string, unknown> {
+  const json = z.toJSONSchema(schema) as Record<string, unknown>;
+  // Remove dialect identifier; MCP clients only need the structural schema.
+  delete json["$schema"];
+  return json;
+}
+
+/**
  * Validate system configuration
  * @throws {Error} when configuration is invalid
  */
@@ -256,7 +277,7 @@ Error Handling:
   - Returns "No videos found" if search is empty
   - Network errors: Check internet connection and retry
   - Rate limits: Wait before searching again`,
-        inputSchema: SearchVideosSchema,
+        inputSchema: toJsonSchema(SearchVideosSchema),
         annotations: {
           readOnlyHint: true,
           destructiveHint: false,
@@ -285,7 +306,7 @@ Don't use when: You want to download subtitles (use ytdlp_download_video_subtitl
 Error Handling:
   - "Invalid or unsupported URL format" for malformed URLs
   - "No subtitle files found" if video has no subtitles`,
-        inputSchema: ListSubtitleLanguagesSchema,
+        inputSchema: toJsonSchema(ListSubtitleLanguagesSchema),
         annotations: {
           readOnlyHint: true,
           destructiveHint: false,
@@ -316,7 +337,7 @@ Error Handling:
   - "Invalid or unsupported URL format" for bad URLs
   - "No subtitle files found" if language is unavailable
   - Use ytdlp_list_subtitle_languages first to check available options`,
-        inputSchema: DownloadVideoSubtitlesSchema,
+        inputSchema: toJsonSchema(DownloadVideoSubtitlesSchema),
         annotations: {
           readOnlyHint: true,
           destructiveHint: false,
@@ -349,7 +370,7 @@ Note: This creates/modifies local files. YouTube has different format handling t
 Error Handling:
   - "Download failed" with details if network errors or invalid URL
   - Check Downloads folder write permissions if saves fail`,
-        inputSchema: DownloadVideoSchema,
+        inputSchema: toJsonSchema(DownloadVideoSchema),
         annotations: {
           readOnlyHint: false,
           destructiveHint: false,
@@ -381,7 +402,7 @@ Error Handling:
   - "Download completed but file not found" if unexpected file naming
   - Check Downloads folder write permissions if saves fail
   - Network errors will show detailed messages`,
-        inputSchema: DownloadAudioSchema,
+        inputSchema: toJsonSchema(DownloadAudioSchema),
         annotations: {
           readOnlyHint: false,
           destructiveHint: false,
@@ -413,7 +434,7 @@ Error Handling:
   - "Invalid or unsupported URL format" for bad URLs
   - "No subtitle files found for transcript generation" if language unavailable
   - Use ytdlp_list_subtitle_languages to check options first`,
-        inputSchema: DownloadTranscriptSchema,
+        inputSchema: toJsonSchema(DownloadTranscriptSchema),
         annotations: {
           readOnlyHint: true,
           destructiveHint: false,
@@ -449,7 +470,7 @@ Error Handling:
   - "Video is unavailable or private" for inaccessible content
   - "Unsupported URL or extractor not found" for unsupported platforms
   - "Network error" with details for connectivity issues`,
-        inputSchema: GetVideoMetadataSchema,
+        inputSchema: toJsonSchema(GetVideoMetadataSchema),
         annotations: {
           readOnlyHint: true,
           destructiveHint: false,
@@ -481,7 +502,7 @@ Don't use when: You need complete structured data (use ytdlp_get_video_metadata 
 
 Error Handling:
   - Same as ytdlp_get_video_metadata (unavailable videos, unsupported URLs, network errors)`,
-        inputSchema: GetVideoMetadataSummarySchema,
+        inputSchema: toJsonSchema(GetVideoMetadataSummarySchema),
         annotations: {
           readOnlyHint: true,
           destructiveHint: false,
@@ -527,7 +548,7 @@ Error Handling:
   - "Comments are disabled" for videos with comments turned off
   - "Requires authentication" for age-restricted content (configure cookies)
   - "Unsupported platform" for non-YouTube URLs`,
-        inputSchema: GetVideoCommentsSchema,
+        inputSchema: toJsonSchema(GetVideoCommentsSchema),
         annotations: {
           readOnlyHint: true,
           destructiveHint: false,
@@ -560,7 +581,7 @@ Note: Comments are sorted by "top" (most liked) by default.
 
 Error Handling:
   - Same as ytdlp_get_video_comments (unavailable videos, disabled comments, authentication required)`,
-        inputSchema: GetVideoCommentsSummarySchema,
+        inputSchema: toJsonSchema(GetVideoCommentsSummarySchema),
         annotations: {
           readOnlyHint: true,
           destructiveHint: false,


### PR DESCRIPTION
## Summary

Since 0.8.4 bumped `zod` to `^4.1.12`, every tool call against this server fails on the client side regardless of whether the client actually sent that argument. The tools become effectively unusable from MCP clients (Claude Desktop, Claude Code, Cowork, etc.).

## Root cause

The MCP protocol requires each tool's `inputSchema` to be a **JSON Schema object**. In `src/index.mts`, the server was passing raw Zod schemas directly:

```ts
{
  name: "ytdlp_search_videos",
  inputSchema: SearchVideosSchema,  // ← Zod schema, not JSON Schema
  ...
}
```

`@modelcontextprotocol/sdk@0.7.0` does **not** auto-convert Zod schemas to JSON Schema. Before 0.8.4 this happened to limp along with Zod v3 (the SDK could partially inspect the schema's shape), but with `zod@^4.1.12` the internal shape changed and clients now receive:

```json
{ "type": "object", "properties": {}, "additionalProperties": false }
```

Clients see an empty parameter set, strip `arguments` to `{}` before sending, and every tool call lands in the server's `CallToolRequest` handler with no inputs — which Zod then (correctly) rejects with `expected string, received undefined`.

This isn't specific to a single client; it's a structural mismatch between what the server publishes and what the protocol requires. Related upstream discussion: anthropics/claude-agent-sdk-typescript#27, modelcontextprotocol/modelcontextprotocol#1072.

## Fix

Add a small `toJsonSchema()` helper that uses Zod v4's built-in `z.toJSONSchema()` (no new dependency, no Zod downgrade) and wrap every tool's `inputSchema` reference with it. The runtime Zod validation inside the `CallToolRequest` handler is unchanged — schemas are still parsed with `XxxSchema.parse(args)` exactly as before.

```ts
function toJsonSchema(schema: ZodType): Record<string, unknown> {
  const json = z.toJSONSchema(schema) as Record<string, unknown>;
  delete json["$schema"];  // MCP clients only need the structural schema
  return json;
}
```

Affected tools (all 10): `ytdlp_search_videos`, `ytdlp_list_subtitle_languages`, `ytdlp_download_video_subtitles`, `ytdlp_download_video`, `ytdlp_download_audio`, `ytdlp_download_transcript`, `ytdlp_get_video_metadata`, `ytdlp_get_video_metadata_summary`, `ytdlp_get_video_comments`, `ytdlp_get_video_comments_summary`.

## Verification

End-to-end against a real MCP client (Claude/Cowork on macOS):

**Before** — every tool call returns: