### PR TITLE
fix(config): honor yt-dlp config file in download tools (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.10.0] - 2026-08-11
+
+### Added
+- `YTDLP_PROXY` environment variable to route yt-dlp requests through a proxy (`http`, `https`, `socks4`, `socks5`, `socks5h`). An empty value forces a direct connection, overriding a proxy set in the yt-dlp config file
+- `YTDLP_IGNORE_CONFIG=1` to opt back into skipping all yt-dlp config files
+- `getGlobalArgs()` in `config.ts`, applied by every tool so proxy and config-file behavior stay consistent across all 10 tools
+
+### Changed
+- **Breaking**: download, audio, subtitle and transcript tools no longer pass `--ignore-config`, so they now honor the yt-dlp config file (`~/.config/yt-dlp/config`) like the metadata, search and comments tools always did. This restores proxy and cookie configuration for MCP clients that cannot inject environment variables into the server process (#30). `YTDLP_IGNORE_CONFIG=1` disables config files for **all** tools, so it is not a straight revert to 0.9.x behavior
+- `ytdlp_download_video` and `ytdlp_download_audio` now report the path yt-dlp emits via `--print after_move:filepath` instead of predicting it with `--get-filename` or reconstructing it. The reported name survives post-processing, `--restrict-filenames` and `--trim-filenames`, and the extra network round-trip per video download is gone
+- All tools now pass `--no-download-archive` explicitly, so a `--download-archive` in a user config file cannot silently skip a request. Without this the `--dump-json` tools received empty output and failed to parse it
+- Download tools now pass `--no-simulate`, so a `--simulate` in a user config file cannot turn a download into a no-op
+- `ytdlp_download_video_subtitles` now pins `--convert-subs vtt`, so a `--convert-subs` in a user config file cannot hide the subtitle files from the tool
+
+### Fixed
+- Proxy settings were previously unreachable for the download, audio, subtitle and transcript tools: `--ignore-config` blocked the config file and no proxy option existed (#30)
+- README no longer documents `YTDLP_CHARACTER_LIMIT` and `YTDLP_MAX_TRANSCRIPT_LENGTH`. Neither was ever read by `loadEnvConfig()`, so setting them had no effect. The underlying `limits` values keep their defaults (25000 / 50000) and remain configurable by passing a config object when using this package as a library
+
+Thanks to @Pheobe-Southwood (#30) for the detailed report and reproduction.
+
+---
+
 ## [0.9.0] - 2026-05-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ Important comments behavior:
 ### Key Patterns
 - **Unified error handling**: `handleToolExecution()` wrapper for consistent error responses
 - **Spawn management**: All external tool calls go through `_spawnPromise()` with cleanup
+- **Global yt-dlp args**: Every invocation prepends `getGlobalArgs(config)` (proxy + config-file handling) — see "yt-dlp Config File Behavior" below
 - **Configuration-driven**: All defaults and behavior configurable via environment variables
 - **ESM modules**: Uses `.mts` extension and ESM imports throughout
 - **Filename sanitization**: Cross-platform safe filename handling with length limits
@@ -103,6 +104,32 @@ Important comments behavior:
 - Filename sanitization rules
 - Temporary directory management
 - Environment variable overrides (YTDLP_* prefix)
+- Proxy passthrough (`YTDLP_PROXY`) and yt-dlp config-file behavior (`YTDLP_IGNORE_CONFIG`)
+
+### yt-dlp Config File Behavior
+Every tool prepends `getGlobalArgs(config)` to its yt-dlp arguments. Keep this
+invariant when adding tools — it is what makes proxy handling uniform.
+
+- Tools do **not** pass `--ignore-config` by default, so the user's yt-dlp
+  config file (`~/.config/yt-dlp/config`) is honored. Some MCP clients cannot
+  inject env vars into the server process, making that file their only way to
+  configure a proxy or cookies (#30).
+- Because a user config file can rewrite output paths, filenames and
+  extensions, download tools must let yt-dlp **report** the produced file
+  rather than predict or reconstruct it. `video.ts` and `audio.ts` pass
+  `--no-simulate --print after_move:filepath` and parse the result via
+  `resolveDownloadedFile()` in `utils.ts`. Do not reintroduce
+  `--get-filename` (it ignores post-processing extension changes) and do not
+  rely on matching the timestamp (`--trim-filenames` and a small
+  `YTDLP_MAX_FILENAME_LENGTH` both destroy it).
+- Tools that locate files by extension must pin that extension on the command
+  line (e.g. `--convert-subs vtt` in `downloadSubtitles`), since CLI args
+  override config-file args.
+- **All** tools pass `--no-download-archive`. A user's `--download-archive`
+  otherwise suppresses the entry entirely — for the `--dump-json` tools that
+  means empty stdout and a JSON parse failure, not just a skipped download.
+- Download tools also pass `--no-simulate`, which both enables `--print` and
+  neutralizes a `--simulate` in the user's config file.
 
 ### Testing Setup
 - **Jest with ESM**: Custom config for TypeScript + ESM support

--- a/README.md
+++ b/README.md
@@ -439,13 +439,67 @@ YTDLP_DEFAULT_RESOLUTION=1080p
 
 # Default subtitle language (default: en)
 YTDLP_DEFAULT_SUBTITLE_LANG=en
-
-# Character limit (default: 25000)
-YTDLP_CHARACTER_LIMIT=25000
-
-# Max transcript length (default: 50000)
-YTDLP_MAX_TRANSCRIPT_LENGTH=50000
 ```
+
+See the [Configuration Guide](./docs/configuration.md) for the full list.
+
+### Proxy and yt-dlp Config File
+
+All tools read your yt-dlp config file (`~/.config/yt-dlp/config`), so any
+`--proxy`, `--cookies` or other options set there apply automatically. This is
+the only channel available to MCP clients that cannot pass environment
+variables to the server process.
+
+These are alternatives — set only the one you need:
+
+| Setting | Effect |
+|---------|--------|
+| `YTDLP_PROXY=socks5://127.0.0.1:1080` | Route all requests through this proxy |
+| `YTDLP_PROXY=` (empty) | Force a direct connection, overriding a proxy in the yt-dlp config file |
+| `YTDLP_IGNORE_CONFIG=1` | Skip all yt-dlp config files |
+
+Supported proxy schemes: `http`, `https`, `socks4`, `socks5`, `socks5h`.
+
+> `YTDLP_IGNORE_CONFIG=1` is not a straight revert to 0.9.x. The search,
+> metadata and comments tools always read the config file, so this setting
+> stops them from doing so as well.
+
+**MCP Configuration with a proxy:**
+
+```json
+{
+  "mcpServers": {
+    "yt-dlp": {
+      "command": "npx",
+      "args": ["-y", "@kevinwatt/yt-dlp-mcp@latest"],
+      "env": {
+        "YTDLP_PROXY": "socks5://127.0.0.1:1080"
+      }
+    }
+  }
+}
+```
+
+If your MCP client cannot pass environment variables to the server, put the
+options in `~/.config/yt-dlp/config` instead — every tool reads that file:
+
+```
+--proxy socks5://127.0.0.1:1080
+--cookies /path/to/cookies.txt
+```
+
+> **Note**: Your config file applies to downloads as well. Options that change
+> the output format (`-x`, `--remux-video`, `--recode-video`) change what the
+> download tools produce; the tools report the file yt-dlp actually wrote, so
+> the reported name stays correct. Output-location options (`-o`, `-P`) have no
+> effect, because the tools always pass an absolute `--output` on the command
+> line, which takes precedence.
+>
+> **Note**: yt-dlp config files can contain options that execute commands
+> (`--exec`, `--postprocessor-args`, `--ffmpeg-location`). These now run on
+> tool invocations too, including ones triggered by an AI assistant. Set
+> `YTDLP_IGNORE_CONFIG=1` if you would rather the server ignore your config
+> file entirely.
 
 ### Cookie Configuration
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -271,7 +271,30 @@ interface Config {
     defaultAudioFormat: "m4a" | "mp3";
     defaultSubtitleLanguage: string;
   };
+  limits: {
+    characterLimit: number;
+    maxTranscriptLength: number;
+  };
+  cookies: {
+    file?: string;
+    fromBrowser?: string;
+  };
+  network: {
+    proxy?: string;
+    ignoreConfig: boolean;
+  };
 }
 ```
+
+### getGlobalArgs(config: Config): string[]
+
+Returns the yt-dlp arguments applied to every invocation: `--ignore-config`
+when `network.ignoreConfig` is set, and `--proxy <url>` when `network.proxy`
+is defined. All tools prepend these to their argument list.
+
+### getCookieArgs(config: Config): string[]
+
+Returns `--cookies <file>` or `--cookies-from-browser <browser>` depending on
+the cookie configuration. `cookies.file` takes precedence.
 
 For detailed configuration options, see [Configuration Guide](./configuration.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,18 @@ interface Config {
     defaultAudioFormat: "m4a" | "mp3";
     defaultSubtitleLanguage: string;
   };
+  limits: {
+    characterLimit: number;
+    maxTranscriptLength: number;
+  };
+  cookies: {
+    file?: string;
+    fromBrowser?: string;
+  };
+  network: {
+    proxy?: string;
+    ignoreConfig: boolean;
+  };
 }
 ```
 
@@ -44,6 +56,31 @@ interface Config {
 | `YTDLP_DEFAULT_RESOLUTION` | Default video resolution | `720p` |
 | `YTDLP_DEFAULT_AUDIO_FORMAT` | Default audio format | `m4a` |
 | `YTDLP_DEFAULT_SUBTITLE_LANG` | Default subtitle language | `en` |
+| `YTDLP_COOKIES_FILE` | Path to a Netscape-format cookie file | — |
+| `YTDLP_COOKIES_FROM_BROWSER` | Browser to extract cookies from | — |
+| `YTDLP_PROXY` | Proxy URL for all yt-dlp requests. Empty value forces a direct connection | — |
+| `YTDLP_IGNORE_CONFIG` | Skip all yt-dlp config files | `false` |
+
+### Proxy and yt-dlp Config File
+
+By default no `--ignore-config` is passed, so every tool honors the user's
+yt-dlp config file (`~/.config/yt-dlp/config`). This is the only way to set a
+proxy or cookies for MCP clients that cannot pass environment variables to the
+server process.
+
+```bash
+# Route requests through a proxy
+export YTDLP_PROXY="socks5://127.0.0.1:1080"
+
+# Force a direct connection, overriding a proxy in the yt-dlp config file
+export YTDLP_PROXY=""
+
+# Skip all yt-dlp config files (pre-0.10.0 behavior)
+export YTDLP_IGNORE_CONFIG=1
+```
+
+Accepted proxy schemes are `http`, `https`, `socks4`, `socks5` and `socks5h`.
+A value with any other scheme is ignored with a warning.
 
 ## File Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kevinwatt/yt-dlp-mcp",
-  "version": "0.8.5",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kevinwatt/yt-dlp-mcp",
-      "version": "0.8.5",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kevinwatt/yt-dlp-mcp",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "An MCP server implementation that integrates with yt-dlp, providing video and audio content download capabilities (e.g. YouTube, Facebook, Tiktok, etc.) for LLMs.",
   "keywords": [
     "mcp",
@@ -27,7 +27,7 @@
   "main": "./lib/index.mjs",
   "scripts": {
     "prepare": "tsc --skipLibCheck && chmod +x ./lib/index.mjs",
-    "test": "PYTHONPATH= PYTHONHOME= node --experimental-vm-modules node_modules/jest/bin/jest.js --detectOpenHandles --forceExit"
+    "test": "PYTHONPATH= PYTHONHOME= YTDLP_IGNORE_CONFIG=1 node --experimental-vm-modules node_modules/jest/bin/jest.js --detectOpenHandles --forceExit"
   },
   "author": "Dewei Yen <k@funmula.com>",
   "license": "MIT",

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -177,3 +177,127 @@ describe('Cookie Configuration', () => {
     });
   });
 });
+
+describe('Network Configuration', () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.YTDLP_PROXY;
+    delete process.env.YTDLP_IGNORE_CONFIG;
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('getGlobalArgs', () => {
+    // Regression guard for issue #30: emitting --ignore-config by default made
+    // the yt-dlp config file unreachable, which is the only way to set a proxy
+    // for clients that cannot inject env vars into the server process.
+    test('does not emit --ignore-config by default', async () => {
+      const { getGlobalArgs, loadConfig } = await import('../config.js');
+      const config = loadConfig();
+
+      expect(getGlobalArgs(config)).toEqual([]);
+      expect(config.network.ignoreConfig).toBe(false);
+    });
+
+    test('emits --ignore-config when opted in', async () => {
+      process.env.YTDLP_IGNORE_CONFIG = '1';
+
+      const { getGlobalArgs, loadConfig } = await import('../config.js');
+
+      expect(getGlobalArgs(loadConfig())).toEqual(['--ignore-config']);
+    });
+
+    test.each(['true', 'yes', 'on', 'ON'])(
+      'treats %s as opting in to --ignore-config',
+      async (value) => {
+        process.env.YTDLP_IGNORE_CONFIG = value;
+
+        const { getGlobalArgs, loadConfig } = await import('../config.js');
+
+        expect(getGlobalArgs(loadConfig())).toEqual(['--ignore-config']);
+      }
+    );
+
+    test.each(['0', 'false', 'no', ''])(
+      'treats %s as leaving the config file enabled',
+      async (value) => {
+        process.env.YTDLP_IGNORE_CONFIG = value;
+
+        const { getGlobalArgs, loadConfig } = await import('../config.js');
+
+        expect(getGlobalArgs(loadConfig())).not.toContain('--ignore-config');
+      }
+    );
+
+    test('emits --proxy when configured', async () => {
+      process.env.YTDLP_PROXY = 'socks5://127.0.0.1:1080';
+
+      const { getGlobalArgs, loadConfig } = await import('../config.js');
+
+      expect(getGlobalArgs(loadConfig())).toEqual([
+        '--proxy',
+        'socks5://127.0.0.1:1080'
+      ]);
+    });
+
+    test('places --ignore-config before --proxy', async () => {
+      process.env.YTDLP_IGNORE_CONFIG = '1';
+      process.env.YTDLP_PROXY = 'http://proxy.local:3128';
+
+      const { getGlobalArgs, loadConfig } = await import('../config.js');
+
+      expect(getGlobalArgs(loadConfig())).toEqual([
+        '--ignore-config',
+        '--proxy',
+        'http://proxy.local:3128'
+      ]);
+    });
+
+    // An empty --proxy value tells yt-dlp to force a direct connection, so it
+    // must survive rather than being treated as "unset".
+    test('preserves an empty proxy as a direct-connection override', async () => {
+      process.env.YTDLP_PROXY = '';
+
+      const { getGlobalArgs, loadConfig } = await import('../config.js');
+
+      expect(getGlobalArgs(loadConfig())).toEqual(['--proxy', '']);
+    });
+
+    test('drops a proxy with no recognised scheme', async () => {
+      process.env.YTDLP_PROXY = 'not-a-proxy';
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { getGlobalArgs, loadConfig } = await import('../config.js');
+      const config = loadConfig();
+
+      expect(config.network.proxy).toBeUndefined();
+      expect(getGlobalArgs(config)).toEqual([]);
+      expect(warn).toHaveBeenCalled();
+
+      warn.mockRestore();
+    });
+
+    test.each([
+      'http://proxy.local:3128',
+      'https://proxy.local:3128',
+      'socks4://127.0.0.1:1080',
+      'socks5://127.0.0.1:1080',
+      'socks5h://127.0.0.1:1080'
+    ])('accepts %s', async (proxy) => {
+      process.env.YTDLP_PROXY = proxy;
+
+      const { getGlobalArgs, loadConfig } = await import('../config.js');
+
+      expect(getGlobalArgs(loadConfig())).toEqual(['--proxy', proxy]);
+    });
+
+    test('tolerates a config object without a network section', async () => {
+      const { getGlobalArgs } = await import('../config.js');
+
+      expect(getGlobalArgs({} as never)).toEqual([]);
+    });
+  });
+});

--- a/src/__tests__/global-args.test.ts
+++ b/src/__tests__/global-args.test.ts
@@ -1,0 +1,149 @@
+// @ts-nocheck
+// @jest-environment node
+import { describe, test, expect, beforeAll, beforeEach, jest } from '@jest/globals';
+import { EventEmitter } from 'events';
+
+/**
+ * Enforces the invariant documented in CLAUDE.md: every tool prepends
+ * getGlobalArgs(config) and passes --no-download-archive.
+ *
+ * Without this, a newly added tool silently loses proxy support, or breaks for
+ * users whose yt-dlp config file sets --download-archive (which suppresses the
+ * entry entirely, leaving the --dump-json tools parsing empty output).
+ */
+
+const PROXY = 'socks5://127.0.0.1:1080';
+const URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+
+// Intercept at the child_process boundary rather than mocking the utils
+// module, so _spawnPromise itself stays real and the argument list observed
+// here is exactly what would reach yt-dlp.
+const spawnMock = jest.fn(() => {
+  const child: any = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  setImmediate(() => child.emit('close', 0));
+  return child;
+});
+
+jest.unstable_mockModule('child_process', () => ({
+  spawn: spawnMock,
+  default: { spawn: spawnMock }
+}));
+
+let config: any;
+let cases: Array<{ name: string; run: () => Promise<unknown> }>;
+
+beforeAll(async () => {
+  // Imported sequentially: Jest's ESM runtime hits module-linking races when
+  // several graphs that share a mocked builtin are linked concurrently.
+  const { loadConfig } = await import('../config.js');
+  const video = await import('../modules/video.js');
+  const audio = await import('../modules/audio.js');
+  const subtitle = await import('../modules/subtitle.js');
+  const metadata = await import('../modules/metadata.js');
+  const search = await import('../modules/search.js');
+  const comments = await import('../modules/comments.js');
+
+  config = { ...loadConfig(), network: { proxy: PROXY, ignoreConfig: true } };
+
+  cases = [
+    { name: 'downloadVideo', run: () => video.downloadVideo(URL, config) },
+    { name: 'downloadAudio', run: () => audio.downloadAudio(URL, config) },
+    { name: 'listSubtitles', run: () => subtitle.listSubtitles(URL, config) },
+    { name: 'downloadSubtitles', run: () => subtitle.downloadSubtitles(URL, 'en', config) },
+    { name: 'downloadTranscript', run: () => subtitle.downloadTranscript(URL, 'en', config) },
+    { name: 'getVideoMetadata', run: () => metadata.getVideoMetadata(URL, undefined, config) },
+    { name: 'getVideoMetadataSummary', run: () => metadata.getVideoMetadataSummary(URL, config) },
+    { name: 'searchVideos', run: () => search.searchVideos('test query', 5, 0, 'json', config) },
+    { name: 'getVideoComments', run: () => comments.getVideoComments(URL, 5, 'top', config) },
+    { name: 'getVideoCommentsSummary', run: () => comments.getVideoCommentsSummary(URL, 5, config) }
+  ];
+});
+
+describe('global yt-dlp argument invariants', () => {
+  beforeEach(() => {
+    // mockClear, not mockReset: the fake child implementation must survive
+    spawnMock.mockClear();
+  });
+
+  // Each tool is driven far enough to build its argument list. Whatever it does
+  // with the empty mock output afterwards is irrelevant here, so failures past
+  // the spawn call are swallowed.
+  async function argsFor(run: () => Promise<unknown>): Promise<string[]> {
+    try {
+      await run();
+    } catch {
+      // ignore: only the arguments handed to yt-dlp matter
+    }
+
+    expect(spawnMock).toHaveBeenCalled();
+    return spawnMock.mock.calls[0][1] as string[];
+  }
+
+  test('every tool is covered by this suite', () => {
+    expect(cases).toHaveLength(10);
+  });
+
+  test.each([
+    'downloadVideo',
+    'downloadAudio',
+    'listSubtitles',
+    'downloadSubtitles',
+    'downloadTranscript',
+    'getVideoMetadata',
+    'getVideoMetadataSummary',
+    'searchVideos',
+    'getVideoComments',
+    'getVideoCommentsSummary'
+  ])('%s prepends getGlobalArgs', async (name) => {
+    const args = await argsFor(cases.find(c => c.name === name)!.run);
+
+    expect(args.slice(0, 3)).toEqual(['--ignore-config', '--proxy', PROXY]);
+  });
+
+  test.each([
+    'downloadVideo',
+    'downloadAudio',
+    'listSubtitles',
+    'downloadSubtitles',
+    'downloadTranscript',
+    'getVideoMetadata',
+    'getVideoMetadataSummary',
+    'searchVideos',
+    'getVideoComments',
+    'getVideoCommentsSummary'
+  ])('%s passes --no-download-archive', async (name) => {
+    const args = await argsFor(cases.find(c => c.name === name)!.run);
+
+    expect(args).toContain('--no-download-archive');
+  });
+
+  test.each(['downloadVideo', 'downloadAudio'])(
+    '%s asks yt-dlp to report the produced path',
+    async (name) => {
+      const args = await argsFor(cases.find(c => c.name === name)!.run);
+
+      // --print implies --simulate, so --no-simulate must accompany it
+      expect(args).toContain('--no-simulate');
+      expect(args).toContain('--print');
+      expect(args[args.indexOf('--print') + 1]).toBe('after_move:filepath');
+    }
+  );
+
+  test('emits no global args when nothing is configured', async () => {
+    const bare = { ...config, network: { proxy: undefined, ignoreConfig: false } };
+    spawnMock.mockClear();
+
+    try {
+      await (await import('../modules/metadata.js')).getVideoMetadata(URL, undefined, bare);
+    } catch {
+      // ignore
+    }
+
+    const args = spawnMock.mock.calls[0][1] as string[];
+    expect(args).not.toContain('--ignore-config');
+    expect(args).not.toContain('--proxy');
+    expect(args[0]).toBe('--dump-json');
+  });
+});

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,0 +1,99 @@
+// @ts-nocheck
+// @jest-environment node
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { resolveDownloadedFile } from '../modules/utils.js';
+
+describe('resolveDownloadedFile', () => {
+  let downloadsDir: string;
+
+  beforeEach(() => {
+    downloadsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ytdlp-resolve-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(downloadsDir, { recursive: true, force: true });
+  });
+
+  const progress = [
+    '[download] Destination: whatever.mp4',
+    '[download]  50.0% of 3.29MiB at 10.75MiB/s ETA 00:00',
+    '[download] 100% of 3.29MiB in 00:00:00 at 11.65MiB/s'
+  ].join('\n');
+
+  test('reads the path yt-dlp printed, ignoring progress output', () => {
+    const filePath = path.join(downloadsDir, 'Title [id] 2026-08-11_12-30-00.mp4');
+    const output = `${progress}\n${filePath}\n`;
+
+    expect(resolveDownloadedFile(output, downloadsDir, '2026-08-11_12-30-00'))
+      .toBe(filePath);
+  });
+
+  // The printed path is authoritative precisely because post-processing and
+  // filename rewrites make the timestamp unreliable — see issue #30 review.
+  test('reports the post-processed name even when the extension changed', () => {
+    const filePath = path.join(downloadsDir, 'Title [id] 2026-08-11_12-30-00.mp3');
+    const output = `${progress}\n${filePath}\n`;
+
+    expect(resolveDownloadedFile(output, downloadsDir, '2026-08-11_12-30-00'))
+      .toBe(filePath);
+  });
+
+  test('reports a name that no longer contains the timestamp', () => {
+    // --trim-filenames / --restrict-filenames can strip the timestamp entirely
+    const filePath = path.join(downloadsDir, 'Rick_Astley_-_Never_Go.m4a');
+    const output = `${progress}\n${filePath}\n`;
+
+    expect(resolveDownloadedFile(output, downloadsDir, '2026-08-11_12-30-00'))
+      .toBe(filePath);
+  });
+
+  test('takes the last printed path when several are present', () => {
+    const first = path.join(downloadsDir, 'first.mp4');
+    const last = path.join(downloadsDir, 'last.mp4');
+    const output = `${first}\n${progress}\n${last}\n`;
+
+    expect(resolveDownloadedFile(output, downloadsDir, 'ts')).toBe(last);
+  });
+
+  // --trim-filenames truncates the whole path, so a config file can land the
+  // download outside the requested directory. Report where it really went.
+  test('accepts a printed path outside the downloads directory', () => {
+    const escaped = path.join(path.sep, 'tmp', 'trimmed.m4a');
+    const output = `${progress}\n${escaped}\n`;
+
+    expect(resolveDownloadedFile(output, downloadsDir, 'ts')).toBe(escaped);
+  });
+
+  test('ignores bracketed verbose lines that mention absolute paths', () => {
+    const output = [
+      "[debug] Loading archive file '/home/user/.yt-dlp-archive'",
+      '[download] Destination: /somewhere/x.mp4'
+    ].join('\n');
+    const real = path.join(downloadsDir, 'Title 2026-08-11_12-30-00.mp4');
+    fs.writeFileSync(real, '');
+
+    expect(resolveDownloadedFile(output, downloadsDir, '2026-08-11_12-30-00')).toBe(real);
+  });
+
+  test('falls back to scanning for the timestamp when nothing was printed', () => {
+    const real = path.join(downloadsDir, 'Title [id] 2026-08-11_12-30-00.mkv');
+    fs.writeFileSync(real, '');
+
+    expect(resolveDownloadedFile(progress, downloadsDir, '2026-08-11_12-30-00')).toBe(real);
+  });
+
+  test('returns undefined when no file matches', () => {
+    expect(resolveDownloadedFile(progress, downloadsDir, '2026-08-11_12-30-00'))
+      .toBeUndefined();
+  });
+
+  // A config-file --simulate produces no download and no directory at all.
+  test('returns undefined instead of throwing when the directory is missing', () => {
+    const missing = path.join(downloadsDir, 'does-not-exist');
+
+    expect(resolveDownloadedFile(progress, missing, 'ts')).toBeUndefined();
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,6 +59,16 @@ export interface Config {
     // Browser name and settings (format: BROWSER[:PROFILE][::CONTAINER])
     fromBrowser?: string;
   };
+  // Network and yt-dlp config-file behavior
+  network: {
+    // Proxy URL passed through to yt-dlp (e.g. socks5://127.0.0.1:1080)
+    proxy?: string;
+    // When true, pass --ignore-config so yt-dlp skips all config files.
+    // Defaults to false so users can configure proxy/cookies via
+    // ~/.config/yt-dlp/config, which is the only channel available to
+    // clients that cannot inject env vars into the MCP server process.
+    ignoreConfig: boolean;
+  };
 }
 
 /**
@@ -95,6 +105,10 @@ const defaultConfig: Config = {
   cookies: {
     file: undefined,
     fromBrowser: undefined
+  },
+  network: {
+    proxy: undefined,
+    ignoreConfig: false
   }
 };
 
@@ -170,7 +184,29 @@ function loadEnvConfig(): DeepPartial<Config> {
     envConfig.cookies = cookiesConfig;
   }
 
+  // Network configuration
+  const networkConfig: Partial<Config['network']> = {};
+  // !== undefined, not truthiness: YTDLP_PROXY="" is a meaningful value that
+  // forces a direct connection, overriding any proxy in the yt-dlp config file.
+  if (process.env.YTDLP_PROXY !== undefined) {
+    networkConfig.proxy = process.env.YTDLP_PROXY;
+  }
+  if (process.env.YTDLP_IGNORE_CONFIG) {
+    networkConfig.ignoreConfig = parseBooleanEnv(process.env.YTDLP_IGNORE_CONFIG);
+  }
+  if (Object.keys(networkConfig).length > 0) {
+    envConfig.network = networkConfig;
+  }
+
   return envConfig;
+}
+
+/**
+ * Parse a boolean-ish environment variable.
+ * Accepts 1/true/yes/on (case-insensitive) as true; everything else is false.
+ */
+function parseBooleanEnv(value: string): boolean {
+  return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
 }
 
 /**
@@ -209,6 +245,36 @@ function validateConfig(config: Config): void {
 
   // Validate cookies (lenient - warnings only)
   validateCookiesConfig(config);
+
+  // Validate network settings (lenient - warnings only)
+  validateNetworkConfig(config);
+}
+
+/**
+ * Validate network configuration (lenient - logs warnings but doesn't throw)
+ */
+function validateNetworkConfig(config: Config): void {
+  if (!config.network) {
+    return;
+  }
+
+  const proxy = config.network.proxy;
+  if (proxy === undefined) {
+    return;
+  }
+
+  // yt-dlp treats an empty --proxy value as "force a direct connection",
+  // so an empty string is meaningful and must be preserved as-is.
+  if (proxy === '') {
+    return;
+  }
+
+  if (!/^(https?|socks[45]|socks5h):\/\//i.test(proxy)) {
+    console.warn(
+      `[yt-dlp-mcp] Invalid proxy URL: ${proxy}. Expected a scheme like http://, https://, socks4://, socks5:// or socks5h://. Continuing without proxy.`
+    );
+    config.network.proxy = undefined;
+  }
 }
 
 /**
@@ -267,6 +333,11 @@ function mergeConfig(base: Config, override: DeepPartial<Config>): Config {
     cookies: {
       file: override.cookies?.file ?? base.cookies.file,
       fromBrowser: override.cookies?.fromBrowser ?? base.cookies.fromBrowser
+    },
+    network: {
+      proxy: override.network?.proxy ?? base.network.proxy,
+      // ?? not || — an explicit `false` override must survive
+      ignoreConfig: override.network?.ignoreConfig ?? base.network.ignoreConfig
     }
   };
 }
@@ -323,6 +394,40 @@ export function getCookieArgs(config: Config): string[] {
     return ['--cookies-from-browser', config.cookies.fromBrowser];
   }
   return [];
+}
+
+/**
+ * Get global yt-dlp arguments that apply to every invocation.
+ *
+ * These must be placed at the front of the argument list so that
+ * `--ignore-config` is seen before yt-dlp resolves configuration files.
+ *
+ * By default no `--ignore-config` is emitted, so yt-dlp honours the user's
+ * config file (`~/.config/yt-dlp/config`). Set `YTDLP_IGNORE_CONFIG=1` to
+ * restore the previous hermetic behaviour.
+ *
+ * @param config Configuration object
+ * @returns Array of yt-dlp arguments applied to all tools
+ */
+export function getGlobalArgs(config: Config): string[] {
+  // Guard against missing network config
+  if (!config.network) {
+    return [];
+  }
+
+  const args: string[] = [];
+
+  if (config.network.ignoreConfig) {
+    args.push('--ignore-config');
+  }
+
+  // Compare against undefined, not truthiness: an empty proxy string is a
+  // valid yt-dlp value meaning "force a direct connection".
+  if (config.network.proxy !== undefined) {
+    args.push('--proxy', config.network.proxy);
+  }
+
+  return args;
 }
 
 // Export current configuration instance

--- a/src/index.mts
+++ b/src/index.mts
@@ -17,7 +17,7 @@ import { searchVideos } from "./modules/search.js";
 import { getVideoMetadata, getVideoMetadataSummary } from "./modules/metadata.js";
 import { getVideoComments, getVideoCommentsSummary } from "./modules/comments.js";
 
-const VERSION = '0.9.0';
+const VERSION = '0.10.0';
 
 // Response format enum
 enum ResponseFormat {

--- a/src/modules/audio.ts
+++ b/src/modules/audio.ts
@@ -1,8 +1,13 @@
-import { readdirSync } from "fs";
 import * as path from "path";
 import type { Config } from "../config.js";
-import { sanitizeFilename, getCookieArgs } from "../config.js";
-import { _spawnPromise, validateUrl, getFormattedTimestamp, isYouTubeUrl } from "./utils.js";
+import { sanitizeFilename, getCookieArgs, getGlobalArgs } from "../config.js";
+import {
+  _spawnPromise,
+  validateUrl,
+  getFormattedTimestamp,
+  isYouTubeUrl,
+  resolveDownloadedFile
+} from "./utils.js";
 
 /**
  * Downloads audio from a video URL in the best available quality.
@@ -45,8 +50,17 @@ export async function downloadAudio(url: string, config: Config): Promise<string
       ? "140/bestaudio[ext=m4a]/bestaudio"
       : "bestaudio[ext=m4a]/bestaudio[ext=mp3]/bestaudio";
 
-    await _spawnPromise("yt-dlp", [
-      "--ignore-config",
+    const output = await _spawnPromise("yt-dlp", [
+      ...getGlobalArgs(config),
+      // A --download-archive in the user's config file would silently skip an
+      // already-downloaded video and leave nothing to report back.
+      "--no-download-archive",
+      // --print implies --simulate; --no-simulate restores the download and
+      // also neutralizes a --simulate coming from the user's config file.
+      "--no-simulate",
+      // Have yt-dlp report the final path instead of predicting it. See
+      // resolveDownloadedFile() for why prediction is not safe here.
+      "--print", "after_move:filepath",
       "--no-check-certificate",
       "--verbose",
       "--progress",
@@ -58,12 +72,12 @@ export async function downloadAudio(url: string, config: Config): Promise<string
       url
     ]);
 
-    const files = readdirSync(config.file.downloadsDir);
-    const downloadedFile = files.find(file => file.includes(timestamp));
-    if (!downloadedFile) {
+    const downloadedPath = resolveDownloadedFile(output, config.file.downloadsDir, timestamp);
+    if (!downloadedPath) {
       throw new Error("Download completed but file not found. Check Downloads folder permissions.");
     }
-    return `Audio successfully downloaded as "${downloadedFile}" to ${config.file.downloadsDir}`;
+    // Report the directory yt-dlp actually used, which a config file can change.
+    return `Audio successfully downloaded as "${path.basename(downloadedPath)}" to ${path.dirname(downloadedPath)}`;
   } catch (error) {
     if (error instanceof Error) {
       if (error.message.includes("Unsupported URL") || error.message.includes("extractor")) {

--- a/src/modules/comments.ts
+++ b/src/modules/comments.ts
@@ -1,5 +1,5 @@
 import type { Config } from "../config.js";
-import { getCookieArgs } from "../config.js";
+import { getCookieArgs, getGlobalArgs } from "../config.js";
 import { _spawnPromise, validateUrl } from "./utils.js";
 import {
   buildCommentExtractorArgs,
@@ -65,7 +65,9 @@ export async function getVideoComments(
   });
 
   const args = [
+    ...(config ? getGlobalArgs(config) : []),
     "--dump-json",
+    "--no-download-archive",
     "--no-warnings",
     "--no-check-certificate",
     "--write-comments",
@@ -112,7 +114,9 @@ export async function getVideoCommentsSummary(
   });
 
   const args = [
+    ...(config ? getGlobalArgs(config) : []),
     "--dump-json",
+    "--no-download-archive",
     "--no-warnings",
     "--no-check-certificate",
     "--write-comments",

--- a/src/modules/metadata.ts
+++ b/src/modules/metadata.ts
@@ -1,5 +1,5 @@
 import type { Config } from "../config.js";
-import { getCookieArgs } from "../config.js";
+import { getCookieArgs, getGlobalArgs } from "../config.js";
 import {
   _spawnPromise,
   validateUrl
@@ -156,7 +156,9 @@ export async function getVideoMetadata(
   }
 
   const args = [
+    ...(_config ? getGlobalArgs(_config) : []),
     "--dump-json",
+    "--no-download-archive",
     "--no-warnings",
     "--no-check-certificate",
     ...(_config ? getCookieArgs(_config) : []),

--- a/src/modules/search.ts
+++ b/src/modules/search.ts
@@ -1,6 +1,6 @@
 import { _spawnPromise } from "./utils.js";
 import type { Config } from "../config.js";
-import { getCookieArgs } from "../config.js";
+import { getCookieArgs, getGlobalArgs } from "../config.js";
 
 /**
  * Upload date filter type
@@ -77,6 +77,7 @@ export async function searchVideos(
       const searchUrl = `https://www.youtube.com/results?search_query=${encodedQuery}&sp=${spParam}`;
 
       args = [
+        ...getGlobalArgs(config),
         searchUrl,
         "--flat-playlist",
         "--print", "title",
@@ -84,6 +85,7 @@ export async function searchVideos(
         "--print", "uploader",
         "--print", "duration",
         "--no-download",
+        "--no-download-archive",
         "--quiet",
         "--playlist-end", String(totalToFetch),
         ...getCookieArgs(config)
@@ -92,12 +94,14 @@ export async function searchVideos(
       // Use ytsearch prefix for regular search
       const searchQuery = `ytsearch${totalToFetch}:${cleanQuery}`;
       args = [
+        ...getGlobalArgs(config),
         searchQuery,
         "--print", "title",
         "--print", "id",
         "--print", "uploader",
         "--print", "duration",
         "--no-download",
+        "--no-download-archive",
         "--quiet",
         ...getCookieArgs(config)
       ];

--- a/src/modules/subtitle.ts
+++ b/src/modules/subtitle.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import type { Config } from '../config.js';
-import { getCookieArgs } from '../config.js';
+import { getCookieArgs, getGlobalArgs } from '../config.js';
 import { _spawnPromise, validateUrl, cleanSubtitleToTranscript } from "./utils.js";
 
 /**
@@ -30,7 +30,8 @@ export async function listSubtitles(url: string, config?: Config): Promise<strin
 
   try {
     const args = [
-      '--ignore-config',
+      ...(config ? getGlobalArgs(config) : []),
+      '--no-download-archive',
       '--list-subs',
       '--write-auto-sub',
       '--skip-download',
@@ -97,10 +98,14 @@ export async function downloadSubtitles(
 
   try {
     await _spawnPromise('yt-dlp', [
-      '--ignore-config',
+      ...getGlobalArgs(config),
+      '--no-download-archive',
       '--write-sub',
       '--write-auto-sub',
       '--sub-lang', language,
+      // Pin the output format: the .vtt filter below would otherwise miss the
+      // files whenever the user's config file sets --convert-subs.
+      '--convert-subs', 'vtt',
       '--skip-download',
       '--output', path.join(tempDir, '%(title)s.%(ext)s'),
       ...getCookieArgs(config),
@@ -176,7 +181,8 @@ export async function downloadTranscript(
 
   try {
     await _spawnPromise('yt-dlp', [
-      '--ignore-config',
+      ...getGlobalArgs(config),
+      '--no-download-archive',
       '--skip-download',
       '--write-subs',
       '--write-auto-subs',

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -1,4 +1,6 @@
 import * as fs from 'fs';
+import * as path from 'path';
+import { readdirSync } from 'fs';
 import { spawn } from 'child_process';
 import { randomBytes } from 'crypto';
 
@@ -146,6 +148,54 @@ export function getFormattedTimestamp(): string {
  * console.log(filename); // '2024-03-20_12-30-00_a1b2c3d4.mp3'
  * ```
  */
+/**
+ * Resolves the absolute path of the file a download actually produced.
+ *
+ * Primary source is the path yt-dlp printed via `--print after_move:filepath`,
+ * which is emitted after post-processing and therefore survives extension
+ * rewrites (`-x`, `--remux-video`), filename rewrites (`--restrict-filenames`)
+ * and truncation (`--trim-filenames`, `YTDLP_MAX_FILENAME_LENGTH`). Any of
+ * those can come from the user's yt-dlp config file, so the path must be
+ * reported by yt-dlp rather than predicted or reconstructed.
+ *
+ * The printed path is accepted even when it falls outside `downloadsDir`:
+ * `--trim-filenames` truncates the whole path, so a config file can move the
+ * download elsewhere entirely. Reporting where the file really landed beats
+ * claiming it is missing.
+ *
+ * Falls back to scanning `downloadsDir` for the timestamp embedded in the
+ * output template, which covers yt-dlp builds that print nothing.
+ *
+ * @param output - stdout captured from the yt-dlp download invocation
+ * @param downloadsDir - Directory the download was requested to be written to
+ * @param timestamp - Timestamp embedded in the output template
+ * @returns Absolute path of the downloaded file, or undefined if none was found
+ */
+export function resolveDownloadedFile(
+  output: string,
+  downloadsDir: string,
+  timestamp: string
+): string | undefined {
+  // yt-dlp prints the final path on its own line. Progress, info and verbose
+  // lines are all bracket-prefixed, so an absolute path is unambiguous.
+  const printed = output
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0 && !line.startsWith('[') && path.isAbsolute(line))
+    .pop();
+
+  if (printed) {
+    return printed;
+  }
+
+  try {
+    const found = readdirSync(downloadsDir).find(file => file.includes(timestamp));
+    return found ? path.join(downloadsDir, found) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function generateRandomFilename(extension: string = 'mp4'): string {
   const timestamp = getFormattedTimestamp();
   const randomId = randomBytes(4).toString('hex');

--- a/src/modules/video.ts
+++ b/src/modules/video.ts
@@ -1,12 +1,12 @@
 import * as path from "path";
 import type { Config } from "../config.js";
-import { sanitizeFilename, getCookieArgs } from "../config.js";
+import { sanitizeFilename, getCookieArgs, getGlobalArgs } from "../config.js";
 import {
   _spawnPromise,
   validateUrl,
   getFormattedTimestamp,
   isYouTubeUrl,
-  generateRandomFilename
+  resolveDownloadedFile
 } from "./utils.js";
 
 /**
@@ -58,119 +58,109 @@ export async function downloadVideo(
     throw new Error("Invalid or unsupported URL format");
   }
 
-  try {
-    const timestamp = getFormattedTimestamp();
+  const timestamp = getFormattedTimestamp();
 
-    let format: string;
-    if (isYouTubeUrl(url)) {
-      // YouTube-specific format selection
-      switch (resolution) {
-        case "480p":
-          format = "bestvideo[height<=480]+bestaudio/best[height<=480]/best";
-          break;
-        case "720p":
-          format = "bestvideo[height<=720]+bestaudio/best[height<=720]/best";
-          break;
-        case "1080p":
-          format = "bestvideo[height<=1080]+bestaudio/best[height<=1080]/best";
-          break;
-        case "best":
-          format = "bestvideo+bestaudio/best";
-          break;
-        default:
-          format = "bestvideo[height<=720]+bestaudio/best[height<=720]/best";
-      }
-    } else {
-      // For other platforms, use quality labels that are more generic
-      switch (resolution) {
-        case "480p":
-          format = "worst[height>=480]/best[height<=480]/worst";
-          break;
-        case "best":
-          format = "bestvideo+bestaudio/best";
-          break;
-        default: // Including 720p and 1080p cases
-          // Prefer HD quality but fallback to best available
-          format = "bestvideo[height>=720]+bestaudio/best[height>=720]/best";
-      }
+  let format: string;
+  if (isYouTubeUrl(url)) {
+    // YouTube-specific format selection
+    switch (resolution) {
+      case "480p":
+        format = "bestvideo[height<=480]+bestaudio/best[height<=480]/best";
+        break;
+      case "720p":
+        format = "bestvideo[height<=720]+bestaudio/best[height<=720]/best";
+        break;
+      case "1080p":
+        format = "bestvideo[height<=1080]+bestaudio/best[height<=1080]/best";
+        break;
+      case "best":
+        format = "bestvideo+bestaudio/best";
+        break;
+      default:
+        format = "bestvideo[height<=720]+bestaudio/best[height<=720]/best";
     }
-
-    let outputTemplate: string;
-    let expectedFilename: string;
-
-    try {
-      // 嘗試獲取檔案名稱
-      outputTemplate = path.join(
-        userDownloadsDir,
-        sanitizeFilename(`%(title)s [%(id)s] ${timestamp}`, config.file) + '.%(ext)s'
-      );
-
-      const getFilenameArgs = [
-        "--ignore-config",
-        "--get-filename",
-        "-f", format,
-        "--output", outputTemplate,
-        ...getCookieArgs(config),
-        url
-      ];
-      expectedFilename = await _spawnPromise("yt-dlp", getFilenameArgs);
-      expectedFilename = expectedFilename.trim();
-    } catch (error) {
-      // 如果無法獲取檔案名稱，使用隨機檔案名
-      const randomFilename = generateRandomFilename('mp4');
-      outputTemplate = path.join(userDownloadsDir, randomFilename);
-      expectedFilename = randomFilename;
+  } else {
+    // For other platforms, use quality labels that are more generic
+    switch (resolution) {
+      case "480p":
+        format = "worst[height>=480]/best[height<=480]/worst";
+        break;
+      case "best":
+        format = "bestvideo+bestaudio/best";
+        break;
+      default: // Including 720p and 1080p cases
+        // Prefer HD quality but fallback to best available
+        format = "bestvideo[height>=720]+bestaudio/best[height>=720]/best";
     }
-
-    // Build download arguments
-    const downloadArgs = [
-      "--ignore-config",
-      "--progress",
-      "--newline",
-      "--no-mtime",
-      "-f", format,
-      "--output", outputTemplate,
-      ...getCookieArgs(config)
-    ];
-
-    // Add trimming parameters if provided
-    if (startTime || endTime) {
-      let downloadSection = "*";
-      
-      if (startTime && endTime) {
-        downloadSection = `*${startTime}-${endTime}`;
-      } else if (startTime) {
-        downloadSection = `*${startTime}-`;
-      } else if (endTime) {
-        downloadSection = `*-${endTime}`;
-      }
-
-      downloadArgs.push("--download-sections", downloadSection, "--force-keyframes-at-cuts");
-    }
-
-    downloadArgs.push(url);
-
-    // Download with progress info
-    try {
-      await _spawnPromise("yt-dlp", downloadArgs);
-    } catch (error) {
-      if (error instanceof Error) {
-        if (error.message.includes("Unsupported URL") || error.message.includes("extractor")) {
-          throw new Error(`Unsupported platform or video URL: ${url}. Ensure the URL is from a supported platform.`);
-        }
-        if (error.message.includes("Video unavailable") || error.message.includes("private")) {
-          throw new Error(`Video is unavailable or private: ${url}. Check the URL and video privacy settings.`);
-        }
-        if (error.message.includes("network") || error.message.includes("Connection")) {
-          throw new Error("Network error during download. Check your internet connection and retry.");
-        }
-        throw new Error(`Download failed: ${error.message}. Check URL and try again.`);
-      }
-      throw new Error(`Download failed: ${String(error)}`);
-    }
-
-    return `Video successfully downloaded as "${path.basename(expectedFilename)}" to ${userDownloadsDir}`;
-  } catch (error) {
-    throw error;
   }
-} 
+
+  const outputTemplate = path.join(
+    userDownloadsDir,
+    sanitizeFilename(`%(title)s [%(id)s] ${timestamp}`, config.file) + '.%(ext)s'
+  );
+
+  // Build download arguments
+  const downloadArgs = [
+    ...getGlobalArgs(config),
+    // A --download-archive in the user's config file would silently skip an
+    // already-downloaded video and leave nothing to report back.
+    "--no-download-archive",
+    // --print implies --simulate; --no-simulate restores the download and
+    // also neutralizes a --simulate coming from the user's config file.
+    "--no-simulate",
+    // Have yt-dlp report the final path instead of predicting it. See
+    // resolveDownloadedFile() for why prediction is not safe here.
+    "--print", "after_move:filepath",
+    "--progress",
+    "--newline",
+    "--no-mtime",
+    "-f", format,
+    "--output", outputTemplate,
+    ...getCookieArgs(config)
+  ];
+
+  // Add trimming parameters if provided
+  if (startTime || endTime) {
+    let downloadSection = "*";
+    
+    if (startTime && endTime) {
+      downloadSection = `*${startTime}-${endTime}`;
+    } else if (startTime) {
+      downloadSection = `*${startTime}-`;
+    } else if (endTime) {
+      downloadSection = `*-${endTime}`;
+    }
+
+    downloadArgs.push("--download-sections", downloadSection, "--force-keyframes-at-cuts");
+  }
+
+  downloadArgs.push(url);
+
+  // Download with progress info
+  let output: string;
+  try {
+    output = await _spawnPromise("yt-dlp", downloadArgs);
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message.includes("Unsupported URL") || error.message.includes("extractor")) {
+        throw new Error(`Unsupported platform or video URL: ${url}. Ensure the URL is from a supported platform.`);
+      }
+      if (error.message.includes("Video unavailable") || error.message.includes("private")) {
+        throw new Error(`Video is unavailable or private: ${url}. Check the URL and video privacy settings.`);
+      }
+      if (error.message.includes("network") || error.message.includes("Connection")) {
+        throw new Error("Network error during download. Check your internet connection and retry.");
+      }
+      throw new Error(`Download failed: ${error.message}. Check URL and try again.`);
+    }
+    throw new Error(`Download failed: ${String(error)}`);
+  }
+
+  const downloadedPath = resolveDownloadedFile(output, userDownloadsDir, timestamp);
+  if (!downloadedPath) {
+    throw new Error("Download completed but file not found. Check Downloads folder permissions.");
+  }
+
+  // Report the directory yt-dlp actually used, which a config file can change.
+  return `Video successfully downloaded as "${path.basename(downloadedPath)}" to ${path.dirname(downloadedPath)}`;
+}


### PR DESCRIPTION
Fixes #30.

## Problem

The download, audio, subtitle and transcript tools passed `--ignore-config`, so `~/.config/yt-dlp/config` was unreachable for them. MCP clients that cannot inject env vars into the server process (the SDK filters to an allowlist when the client does not pass `env`) had no way to configure a proxy or cookies for those tools — while metadata, search and comments worked fine with the same file, since they never passed the flag.

Proxy was in fact unsupported everywhere: there was no `--proxy` anywhere in `src/`.

## Approach

The first instinct — keep `--ignore-config` and neutralize only the dangerous options — turns out to be impossible: `-x`, `--remux-video`, `--recode-video`, `--merge-output-format` and `--paths` have no `--no-` counterpart.

What `--ignore-config` was really protecting was the *file-location contract*, so this PR hardens that contract instead and then drops the flag:

- **`--print after_move:filepath`** replaces `--get-filename`. yt-dlp now *reports* the produced path rather than the code predicting or reconstructing it. Verified to hold with `--restrict-filenames` + `--trim-filenames 25` mangling the name beyond recognition. `--get-filename` never accounted for post-processing extension changes; this does, and it removes a network round-trip per video download.
- **`--no-download-archive` on all 10 call sites.** Verified empirically: with a matching archive entry, `--dump-json` emits **0 bytes and exits 0**, so metadata/comments/search were parsing empty output. This was a latent pre-existing bug that honoring the config file would have made common.
- **`--no-simulate`** on downloads, and **`--convert-subs vtt`** pinned in `downloadSubtitles`, so a config file cannot turn a download into a no-op or hide the subtitle files from the `.vtt` filter.

CLI args override config-file args, and an absolute `--output` makes `-P` inert, so output location is unaffected by the config file.

## Changes

- `getGlobalArgs()` in `config.ts`, prepended by all 10 tools, adding `YTDLP_PROXY` and `YTDLP_IGNORE_CONFIG`
- `resolveDownloadedFile()` in `utils.ts`, shared by `video.ts` and `audio.ts`
- Test suite made hermetic with `YTDLP_IGNORE_CONFIG=1`; it would otherwise read the developer's own config file
- `global-args.test.ts` drives all 10 tools with `child_process.spawn` intercepted, asserting the exact argument list each hands to yt-dlp, so the invariant is enforced rather than merely documented
- README/CHANGELOG/CLAUDE.md/docs updated; `YTDLP_CHARACTER_LIMIT` and `YTDLP_MAX_TRANSCRIPT_LENGTH` removed from the README since `loadEnvConfig()` never read them

## Breaking change

These tools now read the yt-dlp config file. `YTDLP_IGNORE_CONFIG=1` disables config files for **all** tools, so it is not a straight revert to 0.9.x — search, metadata and comments always honored the file.

Config files can also contain `--exec` / `--postprocessor-args`, which now run on tool invocations. This is documented in the README so users can decide whether to keep the default.

## Verification

- 10 test suites, 112 passing (3 skipped); `utils.test.ts` (9 tests) and `global-args.test.ts` (24 tests) added
- The invariant suite was checked for detection power: moving `getGlobalArgs` from the front to the back of the metadata argument list fails exactly the two affected cases and leaves the other 22 passing
- End-to-end with `XDG_CONFIG_HOME` pointed at a throwaway config: config-file proxy takes effect, `YTDLP_IGNORE_CONFIG=1` bypasses it, `YTDLP_PROXY` passes through
- End-to-end with a hostile config: under `--restrict-filenames` the reported filename matches the file on disk exactly
